### PR TITLE
fix: correct adblock request typing, trim report-only CSP, and package MIPS debs/rpms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,19 +434,20 @@ jobs:
         run: cross build --release --target ${{ matrix.target }} --bin privaxy --target-dir target
 
       - name: Build packages
-        if: matrix.target == 'mipsel-unknown-linux-gnu'
+        if: ${{ endsWith(matrix.target, '-linux-gnu') }}
         run: |
-          cargo install cargo-deb && cargo deb --no-build --no-strip --variant mipsel -p privaxy --target ${{ matrix.target }} -o target/${{ matrix.target }}/release
+          variant=$(echo "${{ matrix.target }}" | cut -d- -f1)
+          cargo install cargo-deb && cargo deb --no-build --no-strip --variant "$variant" -p privaxy --target ${{ matrix.target }} -o target/${{ matrix.target }}/release
           cargo install cargo-generate-rpm && cargo generate-rpm -p privaxy --target ${{ matrix.target }} -o target/${{ matrix.target }}/release
 
       - uses: actions/upload-artifact@v4
-        if: matrix.target == 'mipsel-unknown-linux-gnu'
+        if: ${{ endsWith(matrix.target, '-linux-gnu') }}
         with:
           name: privaxy-deb-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/privaxy_*.deb
 
       - uses: actions/upload-artifact@v4
-        if: matrix.target == 'mipsel-unknown-linux-gnu'
+        if: ${{ endsWith(matrix.target, '-linux-gnu') }}
         with:
           name: privaxy-rpm-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/*.rpm

--- a/privaxy/Cargo.toml
+++ b/privaxy/Cargo.toml
@@ -22,6 +22,10 @@ assets = [
 name = "privaxy"
 depends = "libc6, libgcc-s1, libatomic1"
 
+[package.metadata.deb.variants.mips]
+name = "privaxy"
+depends = "libc6, libgcc-s1, libatomic1"
+
 [package.metadata.generate-rpm]
 license = "AGPL-3.0-or-later"
 summary = "Next generation tracker and advertisement blocker"

--- a/privaxy/src/server/blocker.rs
+++ b/privaxy/src/server/blocker.rs
@@ -37,6 +37,11 @@ pub struct CosmeticRequest {
 pub struct NetworkUrl {
     url: String,
     referer: String,
+    // adblock-rust request type string (e.g. "script", "xmlhttprequest",
+    // "image", "sub_frame", "document"). Required for the engine to honour
+    // type-scoped filter and exception rules ($script, $xhr, $image, …);
+    // passing a constant here silently defeats those rules.
+    request_type: String,
 }
 
 #[derive(Debug)]
@@ -204,7 +209,7 @@ impl Blocker {
                     let req = Request::new(
                         network_url.url.as_str(),
                         network_url.referer.as_str(),
-                        "other",
+                        network_url.request_type.as_str(),
                     )
                     .unwrap();
                     let blocker_result = self.engine.check_network_request(&req);
@@ -284,6 +289,7 @@ impl AdblockRequester {
         &self,
         network_url: String,
         referer: String,
+        request_type: String,
     ) -> (bool, adblock::blocker::BlockerResult) {
         let (sender, receiver) = oneshot::channel();
 
@@ -293,6 +299,7 @@ impl AdblockRequester {
                 kind: RequestKind::Url(NetworkUrl {
                     url: network_url,
                     referer,
+                    request_type,
                 }),
             })
             .unwrap();

--- a/privaxy/src/server/configuration/filter.rs
+++ b/privaxy/src/server/configuration/filter.rs
@@ -355,7 +355,7 @@ pub(crate) async fn get_filters_content(
         }
     }
 
-    filters.append(&mut configuration.custom_filters);
+    filters.extend(configuration.custom_filters.iter().cloned());
     filters.sort_unstable();
     // Filter out duplicate lines, if present
     filters.dedup();

--- a/privaxy/src/server/proxy/serve.rs
+++ b/privaxy/src/server/proxy/serve.rs
@@ -222,6 +222,27 @@ fn request_type_from_headers(headers: &HeaderMap) -> &'static str {
     }
 }
 
+/// adblock-rust matches against the literal URL string, so an explicit default
+/// port (`:443` for https, `:80` for http) wedges itself between the host and the
+/// path and breaks hostname-anchored rules (`||host/path`) — the path no longer
+/// follows the host directly. Browsers and uBO match on the canonical URL with
+/// the default port stripped, so we normalise the same way before handing URLs to
+/// the blocker/cosmetic engine. Non-default ports are preserved.
+fn url_for_matching(uri: &Uri) -> String {
+    let scheme = uri.scheme_str().unwrap_or("https");
+    let host = uri.host().unwrap_or("");
+    let path = uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/");
+    let default_port = match scheme {
+        "https" => Some(443),
+        "http" => Some(80),
+        _ => None,
+    };
+    match uri.port_u16() {
+        Some(port) if Some(port) != default_port => format!("{scheme}://{host}:{port}{path}"),
+        _ => format!("{scheme}://{host}{path}"),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn serve(
     adblock_requester: AdblockRequester,
@@ -268,14 +289,19 @@ pub(crate) async fn serve(
 
     let request_type = request_type_from_headers(req.headers()).to_string();
 
+    // Canonical URL (default port stripped) for all adblock-engine matching —
+    // see `url_for_matching`. The raw `uri` (which may carry `:443`) is still
+    // used for the actual outbound request below.
+    let match_url = url_for_matching(&uri);
+
     let (is_request_blocked, blocker_result) = adblock_requester
         .is_network_url_blocked(
-            uri.to_string(),
+            match_url.clone(),
             match req.headers().get(http::header::REFERER) {
                 Some(referer) => referer.to_str().unwrap().to_string(),
                 // When no referer, we default to `uri` as we otherwise may get many false
                 // positives due to the blocker thinking it's third party requests.
-                None => uri.to_string(),
+                None => match_url.clone(),
             },
             request_type.clone(),
         )
@@ -401,12 +427,12 @@ pub(crate) async fn serve(
         // end-of-body cosmetic lookup still runs for hide/style selectors,
         // which depend on collected IDs/classes.
         let injected_script = adblock_requester
-            .get_cosmetic_response(uri.to_string(), Vec::new(), Vec::new())
+            .get_cosmetic_response(match_url.clone(), Vec::new(), Vec::new())
             .await
             .injected_script;
 
         let rewriter = Rewriter::new(
-            uri.to_string(),
+            match_url.clone(),
             adblock_requester,
             receiver_rewriter,
             sender,

--- a/privaxy/src/server/proxy/serve.rs
+++ b/privaxy/src/server/proxy/serve.rs
@@ -192,10 +192,7 @@ fn augment_csp_value(value: &str, nonce: &str) -> String {
 /// Modern browsers send `Sec-Fetch-Dest`, which maps cleanly onto these types.
 /// When it's absent we fall back to sniffing `Accept`, and finally to `other`.
 fn request_type_from_headers(headers: &HeaderMap) -> &'static str {
-    if let Some(dest) = headers
-        .get("sec-fetch-dest")
-        .and_then(|v| v.to_str().ok())
-    {
+    if let Some(dest) = headers.get("sec-fetch-dest").and_then(|v| v.to_str().ok()) {
         return match dest {
             "document" => "document",
             "frame" | "iframe" => "sub_frame",
@@ -220,11 +217,7 @@ fn request_type_from_headers(headers: &HeaderMap) -> &'static str {
         Some(accept) if accept.contains("text/html") => "document",
         Some(accept) if accept.contains("text/css") => "stylesheet",
         Some(accept) if accept.contains("image/") => "image",
-        Some(accept)
-            if accept.contains("javascript") || accept.contains("ecmascript") =>
-        {
-            "script"
-        }
+        Some(accept) if accept.contains("javascript") || accept.contains("ecmascript") => "script",
         _ => "other",
     }
 }

--- a/privaxy/src/server/proxy/serve.rs
+++ b/privaxy/src/server/proxy/serve.rs
@@ -13,9 +13,14 @@ use hyper_rustls::HttpsConnector;
 use std::net::IpAddr;
 use tokio::sync::broadcast;
 
-const CSP_HEADERS: [&str; 4] = [
+// Only *enforcing* CSP headers are augmented. Report-only headers
+// (`content-security-policy-report-only`) are deliberately left untouched:
+// they never block our injected script/style, so augmenting them buys nothing,
+// and doing so would inject our nonce into the site's own violation telemetry
+// and suppress reports the site author relies on (e.g. while testing a strict
+// policy before enforcing it).
+const CSP_HEADERS: [&str; 3] = [
     "content-security-policy",
-    "content-security-policy-report-only",
     "x-content-security-policy",
     "x-webkit-csp",
 ];
@@ -178,6 +183,52 @@ fn augment_csp_value(value: &str, nonce: &str) -> String {
         .join("; ")
 }
 
+/// Map an outgoing request's headers to the adblock-rust request-type string
+/// the engine expects (the same vocabulary as uBO's `$type` options). Without
+/// an accurate type, type-scoped filter and exception rules — e.g. the
+/// `$script`/`$xmlhttprequest` exceptions in uBO's unbreak lists that keep
+/// sites like DuckDuckGo working — match incorrectly and cause false blocks.
+///
+/// Modern browsers send `Sec-Fetch-Dest`, which maps cleanly onto these types.
+/// When it's absent we fall back to sniffing `Accept`, and finally to `other`.
+fn request_type_from_headers(headers: &HeaderMap) -> &'static str {
+    if let Some(dest) = headers
+        .get("sec-fetch-dest")
+        .and_then(|v| v.to_str().ok())
+    {
+        return match dest {
+            "document" => "document",
+            "frame" | "iframe" => "sub_frame",
+            "script" | "serviceworker" | "sharedworker" | "worker" | "audioworklet"
+            | "paintworklet" => "script",
+            "style" => "stylesheet",
+            "image" => "image",
+            "font" => "font",
+            "audio" | "video" | "track" => "media",
+            "object" | "embed" => "object",
+            "report" => "ping",
+            // `empty` is what fetch()/XHR report; treat it as xhr.
+            "empty" | "" => "xmlhttprequest",
+            _ => "other",
+        };
+    }
+
+    match headers
+        .get(http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(accept) if accept.contains("text/html") => "document",
+        Some(accept) if accept.contains("text/css") => "stylesheet",
+        Some(accept) if accept.contains("image/") => "image",
+        Some(accept)
+            if accept.contains("javascript") || accept.contains("ecmascript") =>
+        {
+            "script"
+        }
+        _ => "other",
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn serve(
     adblock_requester: AdblockRequester,
@@ -222,6 +273,8 @@ pub(crate) async fn serve(
 
     statistics.increment_top_clients(client_ip_address);
 
+    let request_type = request_type_from_headers(req.headers()).to_string();
+
     let (is_request_blocked, blocker_result) = adblock_requester
         .is_network_url_blocked(
             uri.to_string(),
@@ -231,6 +284,7 @@ pub(crate) async fn serve(
                 // positives due to the blocker thinking it's third party requests.
                 None => uri.to_string(),
             },
+            request_type.clone(),
         )
         .await;
 
@@ -250,7 +304,20 @@ pub(crate) async fn serve(
             uri.path()
         ));
 
-        log::debug!("Blocked request: {}", uri);
+        // adblock-rust fuses many same-option patterns into one filter and
+        // reports the union as the matched filter, which can be enormous; cap
+        // it so debug logs stay readable.
+        let matched_filter = blocker_result.filter.as_deref().unwrap_or("<none>");
+        let matched_filter = match matched_filter.char_indices().nth(200) {
+            Some((idx, _)) => format!("{}… (truncated)", &matched_filter[..idx]),
+            None => matched_filter.to_string(),
+        };
+        log::debug!(
+            "Blocked request: {} [type={}] matched filter: {}",
+            uri,
+            request_type,
+            matched_filter
+        );
 
         return Ok(get_blocked_by_privaxy_response(blocker_result));
     }


### PR DESCRIPTION
Summary

  1. Adblock request typing — the blocker evaluated every request as type "other", silently defeating type-scoped filter/exception rules ($script,
  $xmlhttprequest, …). Now the real resource type is derived from the request and threaded into the engine.

  Plus a CSP behavior change (stop augmenting report-only headers) and better block-time diagnostics.

  Changes

  Blocker / proxy (serve.rs, blocker.rs)
  - Add request_type_from_headers() mapping Sec-Fetch-Dest (with an Accept-header fallback) to the adblock-rust type vocabulary; thread it through
  is_network_url_blocked → NetworkUrl.request_type → Request::new, replacing the hardcoded "other". Fixes type-scoped rules/exceptions matching incorrectly
  across all sites.
  - CSP: CSP_HEADERS no longer includes content-security-policy-report-only. Report-only headers are left untouched — augmenting them is functionally inert
  (they never block our injected script/style) and was polluting sites' own violation telemetry. Enforcing CSP (content-security-policy + legacy aliases) is
  still nonce-augmented.
  - Block-time debug log now records the assigned [type=…] and the matched filter, truncated to ~200 chars (adblock-rust fuses filters into very long union
  strings).
  - All four engine-matching call sites now use match_url (canonical, default port stripped); the outbound request and stats still use the raw uri with its port, so nothing about proxying changes. **This was silently breaking every hostname-anchored (||host/path) network rule on every HTTPS site**

CI:
  - Added [package.metadata.deb.variants.mips] mirroring mipsel.
  - Result: deb + rpm for mipsel-unknown-linux-gnu and mips-unknown-linux-gnu; musl targets remain binary-only (deb/rpm target glibc).