### PR TITLE
0.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+      - develop
+    tags:
+      - 'v*'
   pull_request:
     branches:
-      - main 
+      - main
+      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,7 +27,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -57,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v6
 
       - name: Install rust
         uses: dtolnay/rust-toolchain@stable
@@ -81,9 +85,11 @@ jobs:
         run: |
           rel="${GITHUB_REF#refs/*/}"
           if grep -qE '^v?\d+\.\d+\.\d+' <<< "$rel" ; then
-            tag="$rel"
-          elif [ "$rel" = "main" ]; then
+            tag="${rel#v}"
+          elif [ "$rel" = "develop" ]; then
             tag="dev"
+          elif [ "$rel" = "main" ]; then
+            tag="latest"
           else
             tag="$(echo "$GITHUB_SHA" | cut -c1-7)"
           fi
@@ -112,7 +118,7 @@ jobs:
             cache_scope: docker-arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download prebuilt binary
         uses: actions/download-artifact@v4
@@ -221,7 +227,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install rust
         uses: dtolnay/rust-toolchain@stable
@@ -307,7 +313,7 @@ jobs:
             target: aarch64-unknown-linux-musl
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Cache build artifacts
         uses: actions/cache@v3
@@ -386,9 +392,15 @@ jobs:
           - build: linux
             os: ubuntu-22.04
             target: mipsel-unknown-linux-musl
+          - build: linux
+            os: ubuntu-22.04
+            target: mips-unknown-linux-musl
+          - build: linux
+            os: ubuntu-22.04
+            target: mips-unknown-linux-gnu
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache build artifacts
         uses: actions/cache@v3
@@ -444,3 +456,37 @@ jobs:
           name: privaxy-${{ matrix.target }}
           path: |
             target/${{ matrix.target }}/release/privaxy
+
+  release:
+    name: Create GitHub Release
+    needs: [ci, ci_mips, image_merge]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+          pattern: privaxy-*
+          merge-multiple: false
+      - name: Set package version from tag
+        run: |
+          echo "PKG_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      - name: Flatten artifacts for release
+        run: |
+          mkdir ./release-assets
+          for dir in ./artifacts/privaxy-*/; do
+            target=$(basename "$dir" | sed 's/^privaxy-//')
+            cp "$dir/privaxy" "./release-assets/privaxy-${PKG_VERSION}-${target}"
+          done
+          find ./artifacts -name '*.deb' -exec cp {} ./release-assets/ \;
+          find ./artifacts -name '*.rpm' -exec cp {} ./release-assets/ \;e '*.rpm' -exec cp {} ./release-assets/ \;
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./release-assets/*
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,19 +434,20 @@ jobs:
         run: cross build --release --target ${{ matrix.target }} --bin privaxy --target-dir target
 
       - name: Build packages
-        if: matrix.target == 'mipsel-unknown-linux-gnu'
+        if: ${{ endsWith(matrix.target, '-linux-gnu') }}
         run: |
-          cargo install cargo-deb && cargo deb --no-build --no-strip --variant mipsel -p privaxy --target ${{ matrix.target }} -o target/${{ matrix.target }}/release
+          variant=$(echo "${{ matrix.target }}" | cut -d- -f1)
+          cargo install cargo-deb && cargo deb --no-build --no-strip --variant "$variant" -p privaxy --target ${{ matrix.target }} -o target/${{ matrix.target }}/release
           cargo install cargo-generate-rpm && cargo generate-rpm -p privaxy --target ${{ matrix.target }} -o target/${{ matrix.target }}/release
 
       - uses: actions/upload-artifact@v4
-        if: matrix.target == 'mipsel-unknown-linux-gnu'
+        if: ${{ endsWith(matrix.target, '-linux-gnu') }}
         with:
           name: privaxy-deb-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/privaxy_*.deb
 
       - uses: actions/upload-artifact@v4
-        if: matrix.target == 'mipsel-unknown-linux-gnu'
+        if: ${{ endsWith(matrix.target, '-linux-gnu') }}
         with:
           name: privaxy-rpm-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/*.rpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,14 +348,10 @@ jobs:
           path: privaxy/prebuilt
 
       - name: Build server
-        uses: actions-rs/cargo@v1
         env:
           CC_x86_64_unknown_linux_musl: musl-gcc
           CC_aarch64_unknown_linux_musl: musl-gcc
-        with:
-          command: build
-          working-directory: .
-          args: --release --target ${{ matrix.target }} --bin privaxy --target-dir target
+        run: cargo build --release --target ${{ matrix.target }} --bin privaxy --target-dir target
       - name: Build packages
         if: ${{ !endsWith(matrix.target, '-musl') }}
         run: |
@@ -483,7 +479,7 @@ jobs:
             cp "$dir/privaxy" "./release-assets/privaxy-${PKG_VERSION}-${target}"
           done
           find ./artifacts -name '*.deb' -exec cp {} ./release-assets/ \;
-          find ./artifacts -name '*.rpm' -exec cp {} ./release-assets/ \;e '*.rpm' -exec cp {} ./release-assets/ \;
+          find ./artifacts -name '*.rpm' -exec cp {} ./release-assets/ \;
 
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.7.0-0.7.1
+## v0.7.1
 
 - Validate filter lists when added
   - Adding a filter now rejects URLs that do not serve a `text/plain` filter list (e.g. an HTML error/landing page returned with a `200`) with a `422`, instead of silently saving a broken filter. The error is surfaced in the web UI, and filters whose URL stops serving a list are dropped from the engine with a warning on the next refresh.
@@ -15,6 +15,18 @@
 - All four engine-matching call sites now use match_url (canonical, default port stripped); the outbound request and stats still use the raw uri with its port, so nothing about proxying changes. This was silently breaking every hostname-anchored (||host/path) network rule on every HTTPS site
 - Update ublock annoyances url
 - Add support for MIPS, MIPSLE
+- Injected uBlock scriptlets now actually run
+  - Even after the 0.7.0 scriptlet repair, every injected `##+js(...)` scriptlet was a silent no-op. adblock-rust emits scriptlet bodies that reference an ambient `scriptletGlobals` object (uBlock Origin supplies it in its own injector; adblock-rust leaves it to the embedder), so the first internal call threw `ReferenceError: scriptletGlobals is not defined`, which each scriptlet's own `try/catch` swallowed. Privaxy now defines `scriptletGlobals` at the top of the injected payload, so `abort-current-script`, `prevent-addEventListener`, `abort-on-property-read`, `set-cookie`, etc. take effect.
+- Procedural cosmetic filtering
+  - Non-CSS procedural filters are no longer dropped (previously only filters reducible to plain CSS were applied). `:has-text`, `:matches-css`/`-before`/`-after`, `:matches-attr`, `:matches-path`, `:min-text-length`, `:upward`, `:xpath`, and the `:remove()`/`:style()`/`remove-attr`/`remove-class` actions are now evaluated in-page by an injected shim.
+  - The shim re-runs on DOM mutations and recurses into same-origin child frames (`about:blank`/`srcdoc`/`data:` with `allow-same-origin`), so ad content written into such frames after load is also matched. Cross-origin frames and closed shadow DOM remain out of reach.
+- Scriptlet error logging (debugging)
+  - New opt-in `debug.scriptlet_console_logging` (off by default), toggleable from Settings → Debug, surfaces errors thrown by injected scriptlets in the page console as `[privaxy scriptlet]` entries instead of swallowing them.
+- Fix cosmetic "modified responses" statistic undercount
+  - Pages where only element-hiding (`display: none`) selectors were injected were not counted as modified; any injected cosmetic CSS now counts
+
+## v0.7.0
+
 - Built-in authentication for the web UI and API
   - First-run setup page for choosing an admin username + password
   - 30-day HMAC-signed session cookie
@@ -31,6 +43,7 @@
 - Fix(?) memory leak
 - Inject into CSP-protected websites
 - Add docker compose example
+
 
 ## v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.7.1
 
+- Fix WebSocket / protocol-upgrade connections hanging
+  - Upgrade requests (`wss://`, and proprietary HTTP-upgrade transports like MMTLS long-link) could spin forever with `upgrade expected but not completed`. The proxy fabricated a `101 Switching Protocols` to the client regardless of what the upstream actually returned, so a failed upgrade left the client waiting on a tunnel that was never bridged. It now forwards the upstream's real response when it isn't a genuine `101`, and the dedicated upgrade HTTP client gained the same connection hardening (`connect_timeout`, `tcp_keepalive`, no idle pooling) as the main client.
+  - Excluded hosts performing a plain-HTTP protocol upgrade are now blind-tunneled at the TCP level instead of being run through the (HTTP-only) upgrade bridge, so MITM-excluded apps using non-HTTP upgrade protocols work. Previously the exclusion list was only consulted on the `CONNECT` path, so excluding such a host had no effect on its plain-HTTP upgrade traffic.
+  - When an opaque (non-WebSocket) upgrade is seen for a host that is *not* excluded, a warning is logged naming the host and suggesting it be added to the exclusions, instead of failing cryptically.
 - Validate filter lists when added
   - Adding a filter now rejects URLs that do not serve a `text/plain` filter list (e.g. an HTML error/landing page returned with a `200`) with a `422`, instead of silently saving a broken filter. The error is surfaced in the web UI, and filters whose URL stops serving a list are dropped from the engine with a warning on the next refresh.
 - Fix proxied requests randomly hanging/timing out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 # Changelog
 
-## Unreleased
+## 0.7.0-0.7.1
 
+- Validate filter lists when added
+  - Adding a filter now rejects URLs that do not serve a `text/plain` filter list (e.g. an HTML error/landing page returned with a `200`) with a `422`, instead of silently saving a broken filter. The error is surfaced in the web UI, and filters whose URL stops serving a list are dropped from the engine with a warning on the next refresh.
+- Fix proxied requests randomly hanging/timing out
+  - The outbound HTTP client had no connection timeouts, so a pooled keep-alive connection silently dropped by the remote would be reused and block until the OS TCP timeout (minutes). Added `connect_timeout`, `pool_idle_timeout`, and `tcp_keepalive`.
+- DNS-over-HTTPS (DoH) interception
+  - Detects DoH requests passing through the MITM proxy (RFC 8484 `application/dns-message`, JSON DoH, and known resolver endpoints)
+  - `block` mode (default) refuses DoH so fallback-mode clients (e.g. default Firefox) revert to the system resolver, which Privaxy already sees — the HTTP-layer equivalent of the `use-application-dns.net` canary a non-DNS proxy cannot serve
+  - `redirect` mode transparently forwards queries to a configured `upstream` resolver
+  - Configured under `[network.doh]` (`mode`, `upstream`, `extra_hosts`) or from the web UI under Settings → General; MITM-excluded hosts are left untouched
+- Fix cookie not invalidating upon logout/cred change
+- All four engine-matching call sites now use match_url (canonical, default port stripped); the outbound request and stats still use the raw uri with its port, so nothing about proxying changes. This was silently breaking every hostname-anchored (||host/path) network rule on every HTTPS site
+- Update ublock annoyances url
+- Add support for MIPS, MIPSLE
 - Built-in authentication for the web UI and API
   - First-run setup page for choosing an admin username + password
   - 30-day HMAC-signed session cookie

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
   - The shim re-runs on DOM mutations and recurses into same-origin child frames (`about:blank`/`srcdoc`/`data:` with `allow-same-origin`), so ad content written into such frames after load is also matched. Cross-origin frames and closed shadow DOM remain out of reach.
 - Scriptlet error logging (debugging)
   - New opt-in `debug.scriptlet_console_logging` (off by default), toggleable from Settings → Debug, surfaces errors thrown by injected scriptlets in the page console as `[privaxy scriptlet]` entries instead of swallowing them.
+- Live log streaming in the web UI
+  - Settings → Debug now shows the server's log output in real time
+  - The level can be changed in the webui
 - Fix cosmetic "modified responses" statistic undercount
   - Pages where only element-hiding (`display: none`) selectors were injected were not counted as modified; any injected cosmetic CSS now counts
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,7 +2037,7 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "privaxy"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "adblock",
  "argon2",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,15 @@
 [target.mipsel-unknown-linux-gnu]
 build-std = true
 
+[target.mips-unknown-linux-gnu]
+build-std = true
+
 [target.mipsel-unknown-linux-musl]
 build-std = true
+[target.mipsel-unknown-linux-musl.env]
+RUSTFLAGS = "-C target-feature=+crt-static"
+
+[target.mips-unknown-linux-musl]
+build-std = true
+[target.mips-unknown-linux-musl.env]
+RUSTFLAGS = "-C target-feature=+crt-static"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,13 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     && cargo build --release; rm src/main.rs
 
 COPY . .
+ARG COMPILE_MODE="release"
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
     --mount=type=cache,target=/root/.npm \
-    cd web_frontend && trunk build --release \
-    && cd .. && cargo build --release \
-    && cp target/release/privaxy /privaxy-out \
+    cd web_frontend && trunk build --${COMPILE_MODE} \
+    && cd .. && cargo build --${COMPILE_MODE} \
+    && cp target/${COMPILE_MODE}/privaxy /privaxy-out \
     && chmod +x /privaxy-out
 
 # Prebuilt path: expect $PREBUILT_BINARY to exist in the build context.

--- a/README.md
+++ b/README.md
@@ -8,27 +8,37 @@
   </p>
 </div>
 
-**Forked from the [app version](https://github.com/Barre/privaxy/tree/v0.5.2)**
+**A fork of [privaxy](https://github.com/Barre/privaxy)**
 
-This reverts it back to [v0.3.1](https://github.com/Barre/privaxy/tree/v0.3.1), but with
-newer updates, an improved UI, and server-friendly configuration. To skip to the differences,
-[see here](#differences)
-
-See features [here](#features)
+This reverts it back to [v0.3.1](https://github.com/Barre/privaxy/tree/v0.3.1), adding more
+features, dependency updates, an improved UI, and server-friendly configuration options.
 
 
-<div align="center">
-<img width="912" alt="dashboard" src="./images/dashboard.png">
-<img width="912" alt="requests" src="./images/requests.png">
-<img width="912" alt="filters" src="./images/filters.png">
-<img width="912" alt="filterlists" src="./images/filterlist.png">
-<img width="912" alt="general" src="./images/general.png">
-<img alt="addfilter" src="./images/addfilter.png">
-</div>
+## Table of Contents
+
+- [About](#about)
+  - [Compared to DNS-based blockers (Pi-hole, AdGuard Home)](#compared-to-dns-based-blockers-pi-hole-adguard-home)
+- [Features](#features)
+- [Installation](#installation)
+  - [Debian/Ubuntu](#debianubuntu)
+  - [RHEL/Fedora/Rocky](#rhelfedorarocky)
+  - [MIPS](#mips)
+  - [Docker](#docker)
+  - [From source](#from-source)
+  - [Docker Compose](#docker-compose)
+- [Setup](#setup)
+  - [First-run web UI](#1-first-run-web-ui)
+  - [Install the root CA on your client devices](#2-install-the-root-ca-on-your-client-devices)
+  - [Point clients at the proxy](#3-point-clients-at-the-proxy)
+  - [Cert-pinned hosts (exclusions)](#4-cert-pinned-hosts-exclusions)
+- [Screenshots](#screenshots)
+- [Acknowledgements](#acknowledgements)
 
 ## About
 
 Privaxy is a MITM HTTP(s) proxy that sits in between HTTP(s) talking applications, such as a web browser and HTTP servers, such as those serving websites.
+
+**This app sees all your plaintext, run it on hardware you trust. DO NOT FACE THIS PUBLICLY**
 
 By establishing a two-way tunnel between both ends, Privaxy is able to block network requests based on URL patterns and to inject scripts as well as styles into HTML documents.
 
@@ -36,7 +46,26 @@ Operating at a lower level, Privaxy is both more efficient as well as more strea
 
 Privaxy is not limited by the browser’s APIs and can operate with any HTTP traffic, not only the traffic flowing from web browsers.
 
-Privaxy is also way more capable than DNS-based blockers as it is able to operate directly on URLs and to inject resources into web pages.
+### Compared to DNS-based blockers (Pi-hole, AdGuard Home)
+
+DNS sinkholes can only answer "is this whole domain allowed or not?". Because
+Privaxy works at the HTTP layer instead of the DNS layer, it can do things a
+DNS blocker fundamentally cannot:
+
+- **Block by full URL, not just domain** — individual paths and query strings
+  can be blocked, so first-party and same-domain ads/trackers (served off a
+  domain you otherwise need) are reachable targets.
+- **Cosmetic filtering** — hide page elements and inject uBlock Origin-style
+  scriptlets, instead of leaving broken gaps where a blocked domain used to be.
+- **Intercept DNS-over-HTTPS (DoH)** — DoH is the mechanism that routinely
+  bypasses DNS-level blockers; Privaxy sees it as HTTPS and can block or
+  redirect it.
+
+The trade-off is that Privaxy is a MITM proxy: clients must trust its root CA
+and route traffic through it, and it sees plaintext. It **complements** a DNS
+blocker more than it strictly replaces one.
+
+**Upon initial setup, a lot of your websites/apps will break due to cert pinning. This is a one time occurrence, add websites/endpoints to exlcusions as broken websites are encountered**
 
 ## Features
 
@@ -48,6 +77,7 @@ Privaxy is also way more capable than DNS-based blockers as it is able to operat
 - Browser and HTTP client agnostic.
 - Support for custom filters.
 - Support for excluding hosts from the MITM pipeline.
+- DNS-over-HTTPS (DoH) interception — `block` (default) clients' DoH so they fall back to the system resolver, or `redirect` queries to a resolver you configure. Closes the DoH bypass that defeats DNS-level blockers.
 - Support for protocol upgrades, such as with websockets.
 - Automatic filter lists updates.
 - Very low resource usage.
@@ -75,7 +105,17 @@ Download and install the deb/rpm/binary with mips in the name
 
 ### Docker
 
-`docker run -d --name privaxy --restart unless-stopped -p 8100:8100 -p 8200:8200 -v /path/to/conf:/conf privaxy:ghcr.io/joshrmcdaniel/privaxy:dev`
+```sh
+docker run -d --name privaxy --restart unless-stopped \
+  -p 8100:8100 -p 8200:8200 \
+  -v /path/to/conf:/conf \
+  ghcr.io/joshrmcdaniel/privaxy:<tag>
+```
+
+- `dev` is mapped to the develop branch
+- `latest` is mapped to the main branch
+- `<version>` maps to official releases
+- `<sha>` maps to a specific commit
 
 ### From source
 
@@ -104,7 +144,7 @@ Build requirements:
 ```yaml
 services:
   privaxy:
-    image: ghcr.io/joshrmcdaniel/privaxy:dev
+    image: ghcr.io/joshrmcdaniel/privaxy
     ports:
       - "8100:8100"
       - "8200:8200"
@@ -112,6 +152,13 @@ services:
       - path/to/conf:/conf
     restart: unless-stopped
 ```
+
+Tags:
+
+- `dev` is mapped to the develop branch
+- `latest` is mapped to the main branch
+- `<version>` maps to official releases
+- `<sha>` maps to a specific commit
 
 ## Setup
 
@@ -192,5 +239,26 @@ to the recommended list.
 > `password_hash` value from the config file and restart. The web UI will
 > force the setup flow again.
 
-### Future
-- Add DNS resolutions; incoporate DNS level blocking?
+## Screenshots
+
+<div align="center">
+<img width="912" alt="dashboard" src="./images/dashboard.png">
+<img width="912" alt="requests" src="./images/requests.png">
+<img width="912" alt="filters" src="./images/filters.png">
+<img width="912" alt="filterlists" src="./images/filterlist.png">
+<img width="912" alt="general" src="./images/general.png">
+<img alt="addfilter" src="./images/addfilter.png">
+</div>
+
+## Acknowledgements
+
+Privaxy was originally created by [Pierre Barre](https://github.com/Barre)
+([Barre/privaxy](https://github.com/Barre/privaxy)). This fork stands on top of
+that work, full credit for the original design and implementation goes to him.
+
+Thanks also to:
+
+- [uBlock Origin](https://github.com/gorhill/uBlock) and [Raymond Hill](https://github.com/gorhill).
+  Privaxy bundles uBlock Origin's scriptlets and web-accessible resources for filter compatibility.
+- [filterlists.com](https://filterlists.com) — for the filter-list directory
+  that powers in-app filter discovery.

--- a/filterlists-api/src/lib.rs
+++ b/filterlists-api/src/lib.rs
@@ -20,7 +20,7 @@ pub async fn get_filters() -> Result<Vec<Filter>, FilterListError> {
 pub async fn get_filter_information(filter: FilterArgs) -> Result<FilterDetails, FilterListError> {
     let id = match filter {
         FilterArgs::U32(id) => id,
-        FilterArgs::Filter(filter) => filter.id.clone(),
+        FilterArgs::Filter(filter) => filter.id,
     };
     _get::<FilterDetails>(&format!("{FILTERLISTS_API_URL}/lists/{id}")).await
 }

--- a/privaxy/Cargo.toml
+++ b/privaxy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "privaxy"
 description = "Next generation tracker and advertisement blocker"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = [
   "Pierre Barre <pierre@barre.sh>",

--- a/privaxy/Cargo.toml
+++ b/privaxy/Cargo.toml
@@ -22,6 +22,10 @@ assets = [
 name = "privaxy"
 depends = "libc6, libgcc-s1, libatomic1"
 
+[package.metadata.deb.variants.mips]
+name = "privaxy"
+depends = "libc6, libgcc-s1, libatomic1"
+
 [package.metadata.generate-rpm]
 license = "AGPL-3.0-or-later"
 summary = "Next generation tracker and advertisement blocker"

--- a/privaxy/src/resources/procedural_cosmetics.js
+++ b/privaxy/src/resources/procedural_cosmetics.js
@@ -1,0 +1,328 @@
+/*
+ * Privaxy in-page procedural cosmetic filtering shim.
+ *
+ * The proxy can apply plain-CSS cosmetic rules server-side by injecting a
+ * <style> block, but uBO/AdGuard procedural rules (:has-text, :matches-css,
+ * :upward, :xpath, :remove(), …) need to be evaluated against the live DOM.
+ * This shim receives those rules as JSON and applies them on load and on every
+ * subsequent DOM mutation.
+ *
+ * Rules are evaluated against the top document AND every reachable child-frame
+ * document. Same-origin frames built without a network fetch (`about:blank`,
+ * `srcdoc`, `data:`) never reach the proxy, so the only way to filter their
+ * contents is from the parent page — which we can do whenever the frame is
+ * same-origin (e.g. a `sandbox` that includes `allow-same-origin`). Cross-origin
+ * frames throw on document access and are silently skipped (those are filtered
+ * via their own proxied response instead).
+ *
+ * Each rule is a ProceduralOrActionFilter:
+ *   { "selector": [ { "type": "css-selector", "arg": "…" }, … ],
+ *     "action":   { "type": "style"|"remove"|"remove-attr"|"remove-class",
+ *                   "arg": "…" } }      // action is optional => hide
+ *
+ * Defined as an idempotent global so repeated injection on a page is harmless.
+ */
+window.__privaxyApplyProcedural = window.__privaxyApplyProcedural || (function () {
+    "use strict";
+
+    var REGEX_LITERAL = /^\/(.*)\/([a-z]*)$/;
+
+    // Build a string predicate from a uBO argument.
+    //   mode "substring" — plain text is a substring test (:has-text, path)
+    //   mode "wildcard"  — plain text supports `*` wildcards, full match
+    // A `/pattern/flags` argument is always treated as a regular expression.
+    function makeMatcher(arg, mode) {
+        var m = REGEX_LITERAL.exec(arg);
+        if (m !== null) {
+            var re = new RegExp(m[1], m[2]);
+            return function (value) {
+                return re.test(value);
+            };
+        }
+        if (mode === "wildcard") {
+            var escaped = arg.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+            var wild = new RegExp("^" + escaped + "$");
+            return function (value) {
+                return wild.test(value);
+            };
+        }
+        return function (value) {
+            return value.indexOf(arg) !== -1;
+        };
+    }
+
+    function uniqueElements(nodes) {
+        var seen = new Set();
+        var out = [];
+        for (var i = 0; i < nodes.length; i++) {
+            var node = nodes[i];
+            if (node && node.nodeType === 1 && !seen.has(node)) {
+                seen.add(node);
+                out.push(node);
+            }
+        }
+        return out;
+    }
+
+    function matchesCss(scope, node, arg, pseudo) {
+        var sep = arg.indexOf(":");
+        if (sep === -1) {
+            return false;
+        }
+        var prop = arg.slice(0, sep).trim();
+        var matcher = makeMatcher(arg.slice(sep + 1).trim(), "wildcard");
+        var style = scope.win.getComputedStyle(node, pseudo || null);
+        return matcher(style.getPropertyValue(prop).trim());
+    }
+
+    function matchesAttr(node, arg) {
+        var sep = arg.indexOf("=");
+        var nameArg = sep === -1 ? arg : arg.slice(0, sep);
+        var nameMatcher = makeMatcher(nameArg.trim(), "wildcard");
+        var valueMatcher = null;
+        if (sep !== -1) {
+            var rawValue = arg.slice(sep + 1).trim().replace(/^["']|["']$/g, "");
+            valueMatcher = makeMatcher(rawValue, "wildcard");
+        }
+        var attrs = node.attributes;
+        for (var i = 0; i < attrs.length; i++) {
+            if (nameMatcher(attrs[i].name)) {
+                if (valueMatcher === null || valueMatcher(attrs[i].value)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    function climbUpward(node, arg) {
+        var steps = parseInt(arg, 10);
+        if (String(steps) === arg.trim()) {
+            var current = node;
+            while (steps-- > 0 && current !== null) {
+                current = current.parentElement;
+            }
+            return current;
+        }
+        return node.parentElement !== null ? node.parentElement.closest(arg) : null;
+    }
+
+    function evaluateXpath(scope, contextNode, arg) {
+        var result = scope.doc.evaluate(
+            arg,
+            contextNode,
+            null,
+            XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+            null
+        );
+        var out = [];
+        for (var i = 0; i < result.snapshotLength; i++) {
+            out.push(result.snapshotItem(i));
+        }
+        return out;
+    }
+
+    // Apply one operator to the running node set within `scope` (a {doc, win}
+    // pair). `nodes` is null until the first selector seeds it from the document.
+    function applyOperator(scope, nodes, op) {
+        var arg = op.arg;
+        switch (op.type) {
+            case "css-selector":
+                if (nodes === null) {
+                    return Array.prototype.slice.call(scope.doc.querySelectorAll(arg));
+                }
+                return nodes.reduce(function (acc, node) {
+                    return acc.concat(Array.prototype.slice.call(node.querySelectorAll(arg)));
+                }, []);
+            case "has-text": {
+                var textMatcher = makeMatcher(arg, "substring");
+                return (nodes || []).filter(function (node) {
+                    return textMatcher(node.textContent || "");
+                });
+            }
+            case "min-text-length": {
+                var minLength = parseInt(arg, 10);
+                return (nodes || []).filter(function (node) {
+                    return (node.textContent || "").length >= minLength;
+                });
+            }
+            case "matches-path": {
+                var pathMatcher = makeMatcher(arg, "substring");
+                var path = scope.win.location.pathname + scope.win.location.search;
+                return pathMatcher(path) ? (nodes || []) : [];
+            }
+            case "matches-css":
+                return (nodes || []).filter(function (node) {
+                    return matchesCss(scope, node, arg, null);
+                });
+            case "matches-css-before":
+                return (nodes || []).filter(function (node) {
+                    return matchesCss(scope, node, arg, "::before");
+                });
+            case "matches-css-after":
+                return (nodes || []).filter(function (node) {
+                    return matchesCss(scope, node, arg, "::after");
+                });
+            case "matches-attr":
+                return (nodes || []).filter(function (node) {
+                    return matchesAttr(node, arg);
+                });
+            case "upward":
+                return uniqueElements((nodes || []).map(function (node) {
+                    return climbUpward(node, arg);
+                }));
+            case "xpath":
+                if (nodes === null) {
+                    return evaluateXpath(scope, scope.doc, arg);
+                }
+                return uniqueElements((nodes || []).reduce(function (acc, node) {
+                    return acc.concat(evaluateXpath(scope, node, arg));
+                }, []));
+            default:
+                return nodes || [];
+        }
+    }
+
+    function selectNodes(scope, selector) {
+        var nodes = null;
+        for (var i = 0; i < selector.length; i++) {
+            nodes = applyOperator(scope, nodes, selector[i]);
+            if (nodes !== null && nodes.length === 0) {
+                return [];
+            }
+        }
+        return uniqueElements(nodes || []);
+    }
+
+    function applyStyle(node, declarations) {
+        declarations.split(";").forEach(function (declaration) {
+            var sep = declaration.indexOf(":");
+            if (sep === -1) {
+                return;
+            }
+            var prop = declaration.slice(0, sep).trim();
+            var value = declaration.slice(sep + 1).trim();
+            var priority = "";
+            if (/!important$/.test(value)) {
+                value = value.replace(/!important$/, "").trim();
+                priority = "important";
+            }
+            if (prop !== "") {
+                node.style.setProperty(prop, value, priority);
+            }
+        });
+    }
+
+    function applyAction(node, action) {
+        if (!action) {
+            node.style.setProperty("display", "none", "important");
+            return;
+        }
+        switch (action.type) {
+            case "style":
+                applyStyle(node, action.arg);
+                break;
+            case "remove":
+                node.remove();
+                break;
+            case "remove-attr":
+                node.removeAttribute(action.arg);
+                break;
+            case "remove-class":
+                node.classList.remove(action.arg);
+                break;
+        }
+    }
+
+    return function (filters) {
+        if (!Array.isArray(filters) || filters.length === 0) {
+            return;
+        }
+
+        var scheduled = false;
+        var observedDocs = new WeakSet();
+
+        // Walk this window and every reachable same-origin descendant frame,
+        // returning a {doc, win} scope for each. Cross-origin frames throw on
+        // document access and are skipped.
+        function collectScopes() {
+            var scopes = [];
+            var seenDocs = new Set();
+            (function visit(win) {
+                var doc;
+                try {
+                    doc = win.document;
+                } catch (err) {
+                    return;
+                }
+                if (!doc || seenDocs.has(doc)) {
+                    return;
+                }
+                seenDocs.add(doc);
+                scopes.push({ doc: doc, win: win });
+                var frames = doc.querySelectorAll("iframe, frame");
+                for (var i = 0; i < frames.length; i++) {
+                    var childWin = null;
+                    try {
+                        childWin = frames[i].contentWindow;
+                    } catch (err) {
+                        childWin = null;
+                    }
+                    if (childWin) {
+                        visit(childWin);
+                    }
+                }
+            })(window);
+            return scopes;
+        }
+
+        // Ads are often written into a frame *after* it's created, and a
+        // parent's observer doesn't see mutations inside a child document, so
+        // each reachable frame document gets its own observer (once).
+        function ensureObserved(doc) {
+            if (observedDocs.has(doc)) {
+                return;
+            }
+            observedDocs.add(doc);
+            var observer = new MutationObserver(schedule);
+            observer.observe(doc.documentElement || doc, { childList: true, subtree: true });
+        }
+
+        function apply() {
+            scheduled = false;
+            var scopes = collectScopes();
+            for (var s = 0; s < scopes.length; s++) {
+                var scope = scopes[s];
+                ensureObserved(scope.doc);
+                for (var i = 0; i < filters.length; i++) {
+                    // A single malformed rule (or a frame torn down mid-pass)
+                    // must not break the rest; throwing is part of normal
+                    // operation here.
+                    try {
+                        var nodes = selectNodes(scope, filters[i].selector);
+                        for (var j = 0; j < nodes.length; j++) {
+                            applyAction(nodes[j], filters[i].action);
+                        }
+                    } catch (err) {
+                        /* ignore this rule and continue */
+                    }
+                }
+            }
+        }
+
+        // Observers only feed `childList` mutations, so our hide/style/attr
+        // edits don't loop; a `:remove()` converges in one extra debounced pass.
+        function schedule() {
+            if (scheduled) {
+                return;
+            }
+            scheduled = true;
+            window.requestAnimationFrame(apply);
+        }
+
+        schedule();
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", schedule);
+        }
+    };
+})();

--- a/privaxy/src/resources/proxy.pac.tera
+++ b/privaxy/src/resources/proxy.pac.tera
@@ -10,22 +10,27 @@ function FindProxyForURL(url, host) {
     if (myIp === "{{ ip }}") return "DIRECT";
     {%- endfor %}
 {%- endif %}
+{%- if cidrs | length > 0 or fqdns | length > 0 %}
+    var hostIsIp = /^\d+\.\d+\.\d+\.\d+$/.test(host) || host.indexOf(":") !== -1;
+{%- endif %}
 {%- if cidrs | length > 0 %}
-    if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
+    if (hostIsIp) {
     {%- for ip, netmask in cidrs %}
         if (isInNet(host, "{{ ip }}", "{{ netmask }}")) return "DIRECT";
     {%- endfor %}
     }
 {%- endif %}
 {%- if fqdns | length > 0 %}
-    var directDomains = [
-    {%- for fqdn in fqdns %}
-        "{{ fqdn }}",
-    {%- endfor %}
-    ];
-    for (var i = 0; i < directDomains.length; i++) {
-        var d = directDomains[i];
-        if (host === d || dnsDomainIs(host, "." + d)) return "DIRECT";
+    if (!hostIsIp) {
+        var directDomains = [
+        {%- for fqdn in fqdns %}
+            "{{ fqdn }}",
+        {%- endfor %}
+        ];
+        for (var i = 0; i < directDomains.length; i++) {
+            var d = directDomains[i];
+            if (host === d || dnsDomainIs(host, "." + d)) return "DIRECT";
+        }
     }
 {%- endif %}
     return "PROXY {{ proxy_host }}";

--- a/privaxy/src/server/blocker.rs
+++ b/privaxy/src/server/blocker.rs
@@ -37,6 +37,11 @@ pub struct CosmeticRequest {
 pub struct NetworkUrl {
     url: String,
     referer: String,
+    // adblock-rust request type string (e.g. "script", "xmlhttprequest",
+    // "image", "sub_frame", "document"). Required for the engine to honour
+    // type-scoped filter and exception rules ($script, $xhr, $image, …);
+    // passing a constant here silently defeats those rules.
+    request_type: String,
 }
 
 #[derive(Debug)]
@@ -204,7 +209,7 @@ impl Blocker {
                     let req = Request::new(
                         network_url.url.as_str(),
                         network_url.referer.as_str(),
-                        "other",
+                        network_url.request_type.as_str(),
                     )
                     .unwrap();
                     let blocker_result = self.engine.check_network_request(&req);
@@ -284,6 +289,7 @@ impl AdblockRequester {
         &self,
         network_url: String,
         referer: String,
+        request_type: String,
     ) -> (bool, adblock::blocker::BlockerResult) {
         let (sender, receiver) = oneshot::channel();
 
@@ -293,6 +299,7 @@ impl AdblockRequester {
                 kind: RequestKind::Url(NetworkUrl {
                     url: network_url,
                     referer,
+                    request_type,
                 }),
             })
             .unwrap();

--- a/privaxy/src/server/blocker.rs
+++ b/privaxy/src/server/blocker.rs
@@ -62,6 +62,11 @@ pub struct CosmeticBlockerResult {
     pub hidden_selectors: Vec<String>,
     pub style_selectors: HashMap<String, Vec<String>>,
     pub injected_script: Option<String>,
+    /// JSON-encoded `ProceduralOrActionFilter` records that cannot be reduced to
+    /// plain CSS (`:has-text`, `:matches-css`, `:upward`, `:xpath`, `:remove()`,
+    /// …). These are handed to the in-page procedural shim, which evaluates them
+    /// against the live DOM. Empty for the vast majority of hosts.
+    pub procedural_filters: Vec<String>,
 }
 
 pub struct BlockerRequest {
@@ -135,6 +140,7 @@ impl Blocker {
                                 hidden_selectors: Vec::new(),
                                 style_selectors: HashMap::new(),
                                 injected_script: None,
+                                procedural_filters: Vec::new(),
                             },
                         ));
                         continue;
@@ -165,20 +171,25 @@ impl Blocker {
 
                     // adblock 0.12 replaced UrlSpecificResources::style_selectors
                     // with `procedural_actions`, a HashSet of JSON-encoded
-                    // ProceduralOrActionFilter records. Re-derive the
-                    // (selector -> style) map from the ones that reduce to
-                    // pure CSS via `as_css()`; non-CSS procedural filters
-                    // (those needing in-page JS to apply) are dropped — the
-                    // proxy can't run JS-driven procedural matching.
+                    // ProceduralOrActionFilter records. Records that reduce to
+                    // pure CSS via `as_css()` are applied server-side as a
+                    // (selector -> style) map. The rest need in-page JS to
+                    // evaluate (`:has-text`, `:matches-css`, `:upward`, `:xpath`,
+                    // `:remove()`, …); their raw JSON is forwarded to the
+                    // procedural shim injected into the page.
                     let mut style_selectors: HashMap<String, Vec<String>> = HashMap::new();
+                    let mut procedural_filters: Vec<String> = Vec::new();
                     for raw in url_specific_resources.procedural_actions.iter() {
                         let Ok(filter) = serde_json::from_str::<
                             adblock::cosmetic_filter_cache::ProceduralOrActionFilter,
                         >(raw) else {
                             continue;
                         };
-                        if let Some((selector, style)) = filter.as_css() {
-                            style_selectors.entry(selector).or_default().push(style);
+                        match filter.as_css() {
+                            Some((selector, style)) => {
+                                style_selectors.entry(selector).or_default().push(style);
+                            }
+                            None => procedural_filters.push(raw.clone()),
                         }
                     }
 
@@ -189,6 +200,7 @@ impl Blocker {
                                 hidden_selectors,
                                 style_selectors,
                                 injected_script,
+                                procedural_filters,
                             }));
                 }
                 RequestKind::Url(network_url) => {

--- a/privaxy/src/server/configuration/filter.rs
+++ b/privaxy/src/server/configuration/filter.rs
@@ -187,7 +187,7 @@ impl DefaultFilters {
             ("https://secure.fanboy.co.nz/fanboy-annoyance.txt", "Fanboy's Annoyance", FilterGroup::Social, false),
             ("https://secure.fanboy.co.nz/fanboy-cookiemonster.txt", "EasyList Cookie", FilterGroup::Social, false),
             ("https://easylist.to/easylist/fanboy-social.txt", "Fanboy's Social", FilterGroup::Social, false),
-            ("https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances.txt", "uBlock filters - Annoyances", FilterGroup::Social, false),
+            ("https://raw.githubusercontent.com/uBlockOrigin/uAssets/refs/heads/master/filters/annoyances-others.txt", "uBlock filters - Annoyances", FilterGroup::Social, false),
         ]
         .into_iter()
         .filter_map(|(url, title, group, enabled_by_default)| Self::parse_filter(url, title, group, enabled_by_default))
@@ -256,6 +256,8 @@ impl Filter {
         let filters_directory = get_filter_directory();
         fs::create_dir_all(&filters_directory).await?;
 
+        // `get_filter` rejects responses that are not served as a filter list (see its
+        // Content-Type check), so an invalid URL never reaches disk.
         let filter = get_filter(self, http_client).await?;
 
         let filter_path = filters_directory.join(&self.file_name);
@@ -302,13 +304,65 @@ impl From<DefaultFilter> for Filter {
     }
 }
 
+/// Returns `Ok(())` only when the response is served as a `text/plain` filter list.
+///
+/// A URL returning a `200` is not sufficient on its own: it may serve an HTML error page, a
+/// redirect landing page or any other content. Filter lists are served as `text/plain`, so a
+/// different Content-Type (most commonly `text/html`) means the URL does not point to a list.
+fn validate_filter_content_type(
+    filter: &Filter,
+    response: &reqwest::Response,
+) -> super::ConfigurationResult<()> {
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    // `starts_with` so that a charset suffix (e.g. `text/plain; charset=utf-8`) still matches.
+    if content_type.starts_with("text/plain") {
+        return Ok(());
+    }
+
+    Err(super::ConfigurationError::FilterValidationError(format!(
+        "The URL for '{}' does not point to a filter list (expected a \"text/plain\" response, got \"{}\")",
+        filter.title,
+        if content_type.is_empty() {
+            "no Content-Type"
+        } else {
+            &content_type
+        }
+    )))
+}
+
+/// Verifies at least one rule is present.
+fn validate_filter_rules(filter: &Filter, contents: &str) -> super::ConfigurationResult<()> {
+    let (network_filters, cosmetic_filters) = adblock::lists::parse_filters(
+        contents.lines(),
+        false,
+        adblock::lists::ParseOptions::default(),
+    );
+
+    if network_filters.is_empty() && cosmetic_filters.is_empty() {
+        return Err(super::ConfigurationError::FilterValidationError(format!(
+            "The URL for '{}' returned no parseable filter rules",
+            filter.title
+        )));
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn get_filter(
     filter: &mut Filter,
     http_client: &reqwest::Client,
 ) -> super::ConfigurationResult<String> {
     let response = http_client.get(filter.url.as_str()).send().await?;
     if response.status().is_success() {
+        validate_filter_content_type(filter, &response)?;
         let content = response.text().await?;
+        validate_filter_rules(filter, &content)?;
         Ok(content)
     } else {
         log::error!(
@@ -349,8 +403,11 @@ pub(crate) async fn get_filters_content(
     for result in results {
         match result {
             Ok(filter_content) => filters.push(filter_content),
+            // A fetch failure here includes a filter whose URL has stopped serving a
+            // `text/plain` list (see `validate_filter_content_type`); we warn and drop it from
+            // the engine rather than aborting the whole rebuild.
             Err(err) => {
-                log::error!("Unable to retrieve filter: {:?}, skipping.", err)
+                log::warn!("Dropping filter that could not be loaded: {err:?}")
             }
         }
     }

--- a/privaxy/src/server/configuration/filter.rs
+++ b/privaxy/src/server/configuration/filter.rs
@@ -355,7 +355,7 @@ pub(crate) async fn get_filters_content(
         }
     }
 
-    filters.append(&mut configuration.custom_filters);
+    filters.extend(configuration.custom_filters.iter().cloned());
     filters.sort_unstable();
     // Filter out duplicate lines, if present
     filters.dedup();

--- a/privaxy/src/server/configuration/mod.rs
+++ b/privaxy/src/server/configuration/mod.rs
@@ -46,6 +46,8 @@ pub enum ConfigurationError {
     UnableToDecodePem(#[from] openssl::error::ErrorStack),
     #[error("filter error: {0}")]
     FilterError(String),
+    #[error("filter validation error: {0}")]
+    FilterValidationError(String),
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -227,6 +229,11 @@ impl Configuration {
             Ok(_) => {
                 self.filters.push(filter.clone());
                 Ok(())
+            }
+            Err(err @ ConfigurationError::FilterValidationError(_)) => {
+                log::warn!("Rejected invalid filter: {err}");
+                filter.enabled = false;
+                Err(err)
             }
             Err(err) => {
                 log::error!("Failed to add filter: {err}");

--- a/privaxy/src/server/configuration/mod.rs
+++ b/privaxy/src/server/configuration/mod.rs
@@ -75,6 +75,10 @@ pub struct DebugConfig {
     /// Privaxy is in the path, so default off.
     #[serde(default)]
     pub scriptlet_console_logging: bool,
+    /// Verbosity of Privaxy's own logs, applied live (no restart). Dependency
+    /// logs remain governed by `RUST_LOG`. Defaults to `info`.
+    #[serde(default)]
+    pub log_level: crate::logging::LogLevel,
 }
 
 #[derive(Error, Debug)]

--- a/privaxy/src/server/configuration/mod.rs
+++ b/privaxy/src/server/configuration/mod.rs
@@ -34,6 +34,8 @@ pub enum ConfigurationError {
     CaError(#[from] CaError),
     #[error("an error occured while trying to deserialize configuration file")]
     DeserializeError(#[from] toml::de::Error),
+    #[error("an error occured while trying to serialize configuration")]
+    SerializeError(#[from] toml::ser::Error),
     #[error("this directory was not found")]
     DirectoryNotFound,
     #[error("file system error")]
@@ -59,6 +61,20 @@ pub struct Configuration {
     pub filters: Vec<Filter>,
     #[serde(default)]
     pub auth: Auth,
+    #[serde(default)]
+    pub debug: DebugConfig,
+}
+
+/// Opt-in diagnostics. Off by default — these add visible/observable behavior to
+/// proxied pages, so they should only be enabled while troubleshooting.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DebugConfig {
+    /// Surface errors thrown by injected uBO scriptlets to the page console
+    /// (`console.error('[privaxy scriptlet]', e)`) instead of swallowing them.
+    /// Useful for spotting a silently-failing scriptlet; noisy and reveals
+    /// Privaxy is in the path, so default off.
+    #[serde(default)]
+    pub scriptlet_console_logging: bool,
 }
 
 #[derive(Error, Debug)]
@@ -130,9 +146,26 @@ impl Configuration {
     pub async fn save(&self) -> ConfigurationResult<()> {
         let configuration_file_path = get_config_file();
 
-        let configuration_serialized = toml::to_string_pretty(&self).unwrap();
+        let configuration_serialized = toml::to_string_pretty(&self)?;
 
-        fs::write(configuration_file_path, configuration_serialized).await?;
+        // Write to a temporary file in the same directory, then atomically
+        // rename it over the target. This guarantees the live config is never
+        // observed in a half-written state: readers see either the old file or
+        // the fully-written new one, even if the process crashes mid-write.
+        let temp_file_path = get_base_directory()?.join(format!(
+            "{CONFIGURATION_FILE_NAME}.{}.tmp",
+            generate_random_hex(8)
+        ));
+
+        if let Err(err) = fs::write(&temp_file_path, configuration_serialized).await {
+            let _ = fs::remove_file(&temp_file_path).await;
+            return Err(ConfigurationError::FileSystemError(err));
+        }
+
+        if let Err(err) = fs::rename(&temp_file_path, &configuration_file_path).await {
+            let _ = fs::remove_file(&temp_file_path).await;
+            return Err(ConfigurationError::FileSystemError(err));
+        }
 
         Ok(())
     }
@@ -312,6 +345,7 @@ impl Configuration {
             ),
             custom_filters: Vec::new(),
             auth: Auth::new_initialized(),
+            debug: DebugConfig::default(),
         })
     }
 }

--- a/privaxy/src/server/configuration/mod.rs
+++ b/privaxy/src/server/configuration/mod.rs
@@ -296,6 +296,7 @@ impl Configuration {
                 pac_direct_ips: Vec::new(),
                 pac_direct_cidrs: std::collections::BTreeMap::new(),
                 pac_direct_fqdns: Vec::new(),
+                doh: DohConfig::default(),
             },
             exclusions: BTreeSet::from_iter(
                 recommended_exclusions()

--- a/privaxy/src/server/configuration/network.rs
+++ b/privaxy/src/server/configuration/network.rs
@@ -66,6 +66,50 @@ pub struct NetworkConfig {
     /// FQDNs (and their subdomains) that bypass the proxy.
     #[serde(default)]
     pub pac_direct_fqdns: Vec<String>,
+    /// DNS-over-HTTPS interception policy. See [`DohConfig`].
+    #[serde(default)]
+    pub doh: DohConfig,
+}
+
+/// What the proxy does with DNS-over-HTTPS (DoH) requests it intercepts.
+///
+/// Privaxy filters at the HTTP layer rather than at DNS resolution time, so DoH
+/// does not bypass blocking the way it bypasses a DNS-level filter — the actual
+/// request to a blocked host is still matched downstream regardless of how it
+/// was resolved. These modes instead let the operator steer how clients resolve
+/// names in the first place.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DohMode {
+    /// Leave DoH requests untouched.
+    Off,
+    /// Refuse DoH requests so the client's DoH attempt fails. Clients in
+    /// fallback mode (e.g. default Firefox) then revert to the system resolver,
+    /// whose lookups flow through Privaxy normally. This is the default: it is
+    /// the HTTP-layer equivalent of the Firefox `use-application-dns.net` canary
+    /// (which a non-DNS proxy cannot serve directly).
+    #[default]
+    Block,
+    /// Transparently forward the opaque DoH query to [`DohConfig::upstream`]
+    /// instead of the resolver the client chose.
+    Redirect,
+}
+
+/// DNS-over-HTTPS interception configuration.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DohConfig {
+    /// How intercepted DoH requests are handled.
+    #[serde(default)]
+    pub mode: DohMode,
+    /// Upstream DoH resolver URL used when `mode = "redirect"`
+    /// (e.g. `https://dns.quad9.net/dns-query`). A redirect with no usable
+    /// upstream fails safe by blocking instead of forwarding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream: Option<String>,
+    /// Additional DoH endpoint hostnames to recognise, on top of the built-in
+    /// list of well-known resolvers.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_hosts: Vec<String>,
 }
 
 #[derive(Error, Debug)]

--- a/privaxy/src/server/lib.rs
+++ b/privaxy/src/server/lib.rs
@@ -358,6 +358,9 @@ async fn privaxy_backend(
     let config = read_configuration(&configuration_save_lock).await;
     let network_config = &config.network;
     let doh_config = network_config.doh.clone();
+    // Read once per (re)start; the backend loop re-runs this on reload, so
+    // toggling the setting in the UI takes effect after its notify_reload.
+    let scriptlet_debug_logging = config.debug.scriptlet_console_logging;
 
     // The hyper client is only used to perform upgrades. We don't need to
     // handle compression.
@@ -390,6 +393,7 @@ async fn privaxy_backend(
                     client_ip_address,
                     local_exclusion_store.clone(),
                     doh_config.clone(),
+                    scriptlet_debug_logging,
                 )
             }))
         }

--- a/privaxy/src/server/lib.rs
+++ b/privaxy/src/server/lib.rs
@@ -25,6 +25,7 @@ mod blocker_utils;
 mod ca;
 mod cert;
 pub mod configuration;
+pub mod logging;
 mod proxy;
 pub mod statistics;
 mod web_gui;
@@ -78,6 +79,11 @@ async fn handle_signals() -> (Arc<Notify>, Arc<Notify>) {
 }
 
 pub async fn start_privaxy() -> PrivaxyServer {
+    // Install the global logger first so every subsequent record is both
+    // written to stderr and made available to the `/api/logs` stream. The
+    // configured level is applied once the configuration is read below.
+    let log_handle = logging::init(logging::LogLevel::default().to_level_filter());
+
     // We use reqwest instead of hyper's client to perform most of the proxying as it's more convenient
     // to handle compression as well as offers a more convenient interface.
     let client = reqwest::Client::builder()
@@ -119,6 +125,10 @@ pub async fn start_privaxy() -> PrivaxyServer {
             std::process::exit(1)
         }
     };
+
+    // Apply the persisted application log level now that configuration is
+    // available; the web UI can change it on the fly afterwards.
+    log_handle.set_level(configuration.debug.log_level.to_level_filter());
 
     let local_exclusion_store =
         LocalExclusionStore::new(Vec::from_iter(configuration.exclusions.clone().into_iter()));
@@ -182,6 +192,7 @@ pub async fn start_privaxy() -> PrivaxyServer {
     let configuration_updater_tx_ref = configuration_updater_tx.clone();
     let configuration_save_lock_ref = configuration_save_lock.clone();
     let broadcast_tx_ref = broadcast_tx.clone();
+    let log_handle_ref = log_handle.clone();
     let notify_reload_clone = notify_reload.clone();
 
     tokio::spawn(async move {
@@ -197,6 +208,7 @@ pub async fn start_privaxy() -> PrivaxyServer {
                 configuration_updater_tx_ref.clone(),
                 cfg_lock_frontend.clone(),
                 notify_reload_frontend.clone(),
+                log_handle_ref.clone(),
             )
             .await;
             notify_reload_frontend.notified().await;
@@ -262,6 +274,7 @@ async fn privaxy_frontend(
     configuration_updater_tx: tokio::sync::mpsc::Sender<configuration::Configuration>,
     configuration_save_lock: Arc<tokio::sync::Mutex<()>>,
     notify_reload: Arc<tokio::sync::Notify>,
+    log_handle: logging::LogHandle,
 ) {
     let frontend = web_gui::get_frontend(
         broadcast_tx.clone(),
@@ -271,6 +284,7 @@ async fn privaxy_frontend(
         &configuration_save_lock,
         &local_exclusion_store,
         notify_reload.clone(),
+        log_handle.clone(),
     );
     let frontend_server = warp::serve(frontend);
     let config = read_configuration(&configuration_save_lock).await;

--- a/privaxy/src/server/lib.rs
+++ b/privaxy/src/server/lib.rs
@@ -338,6 +338,7 @@ async fn privaxy_backend(
         .build();
     let config = read_configuration(&configuration_save_lock).await;
     let network_config = &config.network;
+    let doh_config = network_config.doh.clone();
 
     // The hyper client is only used to perform upgrades. We don't need to
     // handle compression.
@@ -355,6 +356,7 @@ async fn privaxy_backend(
         let broadcast_tx = broadcast_tx.clone();
         let statistics = statistics.clone();
         let local_exclusion_store = local_exclusion_store.clone();
+        let doh_config = doh_config.clone();
 
         async move {
             Ok::<_, Infallible>(service_fn(move |req| {
@@ -368,6 +370,7 @@ async fn privaxy_backend(
                     statistics.clone(),
                     client_ip_address,
                     local_exclusion_store.clone(),
+                    doh_config.clone(),
                 )
             }))
         }

--- a/privaxy/src/server/lib.rs
+++ b/privaxy/src/server/lib.rs
@@ -364,11 +364,20 @@ async fn privaxy_backend(
     configuration_save_lock: Arc<tokio::sync::Mutex<()>>,
     notify_reload: Arc<tokio::sync::Notify>,
 ) {
+    // Mirror the reqwest client's connection hardening (see above): without a
+    // connect timeout and OS-level keepalive, an upgrade can hang on a pooled
+    // keep-alive connection the remote has silently dropped, surfacing as
+    // "upgrade expected but not completed".
+    let mut http_connector = hyper::client::HttpConnector::new();
+    http_connector.enforce_http(false);
+    http_connector.set_connect_timeout(Some(Duration::from_secs(10)));
+    http_connector.set_keepalive(Some(Duration::from_secs(60)));
+
     let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
         .with_native_roots()
         .https_or_http()
         .enable_http1()
-        .build();
+        .wrap_connector(http_connector);
     let config = read_configuration(&configuration_save_lock).await;
     let network_config = &config.network;
     let doh_config = network_config.doh.clone();
@@ -380,7 +389,12 @@ async fn privaxy_backend(
     // handle compression.
     // Hyper's client don't follow redirects, which is what we want, nothing to
     // disable here.
-    let hyper_client = Client::builder().build(https_connector);
+    // An upgraded connection is consumed by the tunnel anyway, so idle pooling
+    // buys nothing and only risks reusing a stale connection under a long-lived
+    // WebSocket — disable it.
+    let hyper_client = Client::builder()
+        .pool_max_idle_per_host(0)
+        .build(https_connector);
 
     let make_service = make_service_fn(move |conn: &AddrStream| {
         let client_ip_address = conn.remote_addr().ip();

--- a/privaxy/src/server/lib.rs
+++ b/privaxy/src/server/lib.rs
@@ -87,6 +87,25 @@ pub async fn start_privaxy() -> PrivaxyServer {
         .gzip(true)
         .brotli(true)
         .deflate(true)
+        // Without these, a proxied request can hang indefinitely on a pooled
+        // keep-alive connection the remote has silently dropped: reqwest reuses
+        // the dead connection and waits on a peer that will never answer.
+        // Retiring idle connections quickly (well under typical server keep-alive
+        // windows) plus OS-level keepalive probes bounds that. `connect_timeout`
+        // additionally fails fast on unreachable hosts.
+        .connect_timeout(Duration::from_secs(10))
+        .pool_idle_timeout(Duration::from_secs(30))
+        .tcp_keepalive(Duration::from_secs(60))
+        // h2-heavy origins multiplex every subresource over a
+        // single connection whose flow-control window defaults to a small,
+        // shared 64 KB. When we drain one stream's body slowly (the browser
+        // reads slowly, or the HTML rewriter backpressures), that window fills
+        // and stalls *every other stream* on the connection — head-of-line
+        // stutter across the whole site. Adaptive flow control grows the
+        // stream/connection windows based on the bandwidth-delay product,
+        // relieving the stall while keeping multiplexing. (This overrides any
+        // manual http2_initial_*_window_size, which is why none are set.)
+        .http2_adaptive_window(true)
         .build()
         .unwrap();
 
@@ -376,7 +395,7 @@ async fn privaxy_backend(
         }
     });
 
-    let ip = env_or_config_ip(&network_config).await;
+    let ip = env_or_config_ip(network_config).await;
     let proxy_server_addr = SocketAddr::from((ip, network_config.proxy_port));
 
     let server = Server::bind(&proxy_server_addr)

--- a/privaxy/src/server/logging.rs
+++ b/privaxy/src/server/logging.rs
@@ -1,0 +1,231 @@
+//! Global logging setup that mirrors `env_logger`'s stderr output while also
+//! fanning every emitted record out to in-process subscribers.
+//!
+//! The standard `log` facade only permits a single global logger, and
+//! `env_logger` writes exclusively to stderr with no hook to observe records.
+//! [`init`] therefore builds `env_logger::Logger`s for stderr formatting, then
+//! wraps them so each record is additionally pushed into a bounded ring buffer
+//! (for backlog replay) and broadcast to live WebSocket subscribers (see
+//! `web_gui::logs`).
+//!
+//! Verbosity of the application's own (`privaxy`-targeted) records is governed
+//! by a [`LogHandle`]'s atomic level, which the web UI can change on the fly
+//! via the Debug settings — no restart or `RUST_LOG` change required. Records
+//! from dependencies keep their `RUST_LOG`-derived filtering so the stream
+//! isn't drowned in third-party noise.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Utc};
+use log::{LevelFilter, Log, Metadata, Record};
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+/// Crate name used both as the logging target prefix for the application's own
+/// records and to decide which records the dynamic level applies to.
+const APP_TARGET: &str = "privaxy";
+
+/// Number of recent records retained for replay to clients that connect after
+/// the records were emitted.
+const BACKLOG_CAPACITY: usize = 1000;
+
+/// Bound on the broadcast channel. Slow subscribers that fall further behind
+/// than this are signalled with `Lagged` and skip the dropped records rather
+/// than stalling the logger.
+const CHANNEL_CAPACITY: usize = 512;
+
+/// Default level for dependency (non-`privaxy`) records when `RUST_LOG` doesn't
+/// say otherwise. Keeps third-party crates quiet so the stream stays readable.
+const DEPENDENCY_DEFAULT_LEVEL: LevelFilter = LevelFilter::Warn;
+
+/// A configurable log verbosity, persisted in the configuration and selectable
+/// from the web UI. Mirrors `log::LevelFilter` but owns its serialized form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl Default for LogLevel {
+    fn default() -> Self {
+        Self::Info
+    }
+}
+
+impl LogLevel {
+    pub fn to_level_filter(self) -> LevelFilter {
+        match self {
+            Self::Off => LevelFilter::Off,
+            Self::Error => LevelFilter::Error,
+            Self::Warn => LevelFilter::Warn,
+            Self::Info => LevelFilter::Info,
+            Self::Debug => LevelFilter::Debug,
+            Self::Trace => LevelFilter::Trace,
+        }
+    }
+}
+
+/// A single formatted log record, serialized to WebSocket clients.
+#[derive(Debug, Clone, Serialize)]
+pub struct LogEntry {
+    pub now: DateTime<Utc>,
+    pub level: String,
+    pub target: String,
+    pub message: String,
+}
+
+/// Cheap-to-clone handle giving access to the live log broadcast, the retained
+/// backlog, and the runtime-adjustable application log level. Shared with the
+/// API layer so a new subscriber can be primed with recent history and the
+/// Debug settings route can change verbosity live.
+#[derive(Clone)]
+pub struct LogHandle {
+    pub sender: broadcast::Sender<LogEntry>,
+    pub backlog: Arc<Mutex<VecDeque<LogEntry>>>,
+    level: Arc<AtomicUsize>,
+}
+
+impl LogHandle {
+    /// Snapshot of the currently retained records, oldest first.
+    pub fn backlog_snapshot(&self) -> Vec<LogEntry> {
+        match self.backlog.lock() {
+            Ok(backlog) => backlog.iter().cloned().collect(),
+            Err(poisoned) => poisoned.get_ref().iter().cloned().collect(),
+        }
+    }
+
+    /// Changes the verbosity applied to the application's own records,
+    /// effective immediately for subsequent records.
+    pub fn set_level(&self, level: LevelFilter) {
+        self.level.store(level as usize, Ordering::Relaxed);
+    }
+
+    fn app_level(&self) -> LevelFilter {
+        level_filter_from_usize(self.level.load(Ordering::Relaxed))
+    }
+
+    fn record(&self, entry: LogEntry) {
+        if let Ok(mut backlog) = self.backlog.lock() {
+            if backlog.len() == BACKLOG_CAPACITY {
+                backlog.pop_front();
+            }
+            backlog.push_back(entry.clone());
+        }
+        // A send error only means there are no live subscribers; the backlog
+        // still captured the record, so the error is intentionally ignored.
+        let _ = self.sender.send(entry);
+    }
+}
+
+fn level_filter_from_usize(value: usize) -> LevelFilter {
+    match value {
+        0 => LevelFilter::Off,
+        1 => LevelFilter::Error,
+        2 => LevelFilter::Warn,
+        3 => LevelFilter::Info,
+        4 => LevelFilter::Debug,
+        _ => LevelFilter::Trace,
+    }
+}
+
+fn is_app_target(target: &str) -> bool {
+    target == APP_TARGET || target.starts_with(concat!("privaxy", "::"))
+}
+
+struct BroadcastLogger {
+    /// Pass-through formatter/writer for the application's own records; its own
+    /// filter is wide open so the dynamic level is the sole gate.
+    app_writer: env_logger::Logger,
+    /// `RUST_LOG`-derived formatter/filter for dependency records.
+    dependency_logger: env_logger::Logger,
+    handle: LogHandle,
+}
+
+impl BroadcastLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        if is_app_target(metadata.target()) {
+            metadata.level() <= self.handle.app_level()
+        } else {
+            self.dependency_logger.enabled(metadata)
+        }
+    }
+}
+
+impl Log for BroadcastLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.enabled(metadata)
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        if is_app_target(record.target()) {
+            self.app_writer.log(record);
+        } else {
+            self.dependency_logger.log(record);
+        }
+
+        self.handle.record(LogEntry {
+            now: Utc::now(),
+            level: record.level().to_string(),
+            target: record.target().to_string(),
+            message: record.args().to_string(),
+        });
+    }
+
+    fn flush(&self) {
+        self.app_writer.flush();
+        self.dependency_logger.flush();
+    }
+}
+
+/// Installs the global logger and returns a [`LogHandle`] for streaming records
+/// to clients and adjusting verbosity at runtime.
+///
+/// `initial_level` seeds the application log level (typically from
+/// configuration). Dependency records are filtered via `RUST_LOG`, defaulting
+/// to [`DEPENDENCY_DEFAULT_LEVEL`].
+///
+/// Must be called exactly once, before any logging occurs.
+pub fn init(initial_level: LevelFilter) -> LogHandle {
+    // Wide-open writer: every application record we hand it is already gated by
+    // the dynamic level, so its own filter must not drop anything.
+    let app_writer = env_logger::Builder::new()
+        .filter_level(LevelFilter::Trace)
+        .build();
+
+    // Dependency records keep RUST_LOG behaviour on top of a quiet default.
+    let dependency_logger = env_logger::Builder::new()
+        .filter_level(DEPENDENCY_DEFAULT_LEVEL)
+        .parse_default_env()
+        .build();
+
+    let (sender, _receiver) = broadcast::channel(CHANNEL_CAPACITY);
+    let handle = LogHandle {
+        sender,
+        backlog: Arc::new(Mutex::new(VecDeque::with_capacity(BACKLOG_CAPACITY))),
+        level: Arc::new(AtomicUsize::new(initial_level as usize)),
+    };
+
+    let logger = BroadcastLogger {
+        app_writer,
+        dependency_logger,
+        handle: handle.clone(),
+    };
+
+    log::set_boxed_logger(Box::new(logger)).expect("failed to install global logger");
+    // Keep the facade permissive so the dynamic level can be raised to Trace at
+    // runtime; the wrapper performs the actual per-record gating.
+    log::set_max_level(LevelFilter::Trace);
+
+    handle
+}

--- a/privaxy/src/server/main.rs
+++ b/privaxy/src/server/main.rs
@@ -9,8 +9,6 @@ async fn main() {
         std::env::set_var(RUST_LOG_ENV_KEY, "privaxy=info");
     }
 
-    env_logger::init();
-
     start_privaxy().await;
 
     loop {

--- a/privaxy/src/server/proxy/doh.rs
+++ b/privaxy/src/server/proxy/doh.rs
@@ -1,0 +1,113 @@
+//! Detection and policy for DNS-over-HTTPS (DoH) requests flowing through the
+//! MITM proxy.
+//!
+//! Privaxy filters at the HTTP layer, not at DNS-resolution time, so DoH does
+//! not bypass blocking the way it bypasses a DNS-level filter. This module
+//! instead lets the operator either refuse DoH outright — pushing fallback-mode
+//! clients (e.g. default Firefox) back onto the system resolver, whose lookups
+//! already traverse the proxy — or transparently redirect DoH queries to a
+//! chosen upstream resolver.
+
+use crate::configuration::{DohConfig, DohMode};
+use http::{HeaderMap, Method, Uri};
+
+/// Well-known DoH endpoint hostnames. Used as a secondary signal (alongside the
+/// RFC 8484 `application/dns-message` content type) to catch JSON DoH and
+/// clients that omit the canonical media type.
+const KNOWN_DOH_HOSTS: [&str; 12] = [
+    "cloudflare-dns.com",
+    "mozilla.cloudflare-dns.com",
+    "dns.google",
+    "dns.google.com",
+    "dns.quad9.net",
+    "doh.opendns.com",
+    "dns.nextdns.io",
+    "firefox.dns.nextdns.io",
+    "doh.cleanbrowsing.org",
+    "dns.adguard-dns.com",
+    "doh.dns.sb",
+    "dns.controld.com",
+];
+
+const DOH_MEDIA_TYPES: [&str; 2] = ["application/dns-message", "application/dns-json"];
+
+/// What to do with a request the proxy has (or has not) identified as DoH.
+#[derive(Debug, Clone)]
+pub(crate) enum DohAction {
+    /// Not DoH, or the feature is disabled: handle the request normally.
+    Passthrough,
+    /// Refuse the request so the client's DoH attempt fails.
+    Block,
+    /// Forward the query to this upstream DoH resolver URL instead.
+    Redirect(String),
+}
+
+fn header_advertises_doh(headers: &HeaderMap, name: http::header::HeaderName) -> bool {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            let value = value.to_ascii_lowercase();
+            DOH_MEDIA_TYPES.iter().any(|media| value.contains(media))
+        })
+        .unwrap_or(false)
+}
+
+fn host_is_known_doh(host: &str, extra_hosts: &[String]) -> bool {
+    let host = host.to_ascii_lowercase();
+    let is_match = |candidate: &str| host == candidate || host.ends_with(&format!(".{candidate}"));
+    KNOWN_DOH_HOSTS.iter().any(|h| is_match(h)) || extra_hosts.iter().any(|h| is_match(h))
+}
+
+/// A request is treated as DoH when it carries the RFC 8484 media type (the
+/// authoritative signal, exclusive to DoH for both `Content-Type` on POST and
+/// `Accept` on GET) or when it targets a known DoH endpoint with a query-shaped
+/// path (covering JSON DoH that may arrive with a generic `Accept` header).
+fn is_doh_request(headers: &HeaderMap, uri: &Uri, extra_hosts: &[String]) -> bool {
+    if header_advertises_doh(headers, http::header::CONTENT_TYPE)
+        || header_advertises_doh(headers, http::header::ACCEPT)
+    {
+        return true;
+    }
+
+    let host = uri.host().unwrap_or("");
+    if !host_is_known_doh(host, extra_hosts) {
+        return false;
+    }
+
+    uri.path().contains("dns-query")
+        || uri
+            .query()
+            .map(|query| query.contains("dns=") || query.contains("name="))
+            .unwrap_or(false)
+}
+
+/// Decide how to handle a request given the configured DoH policy.
+pub(crate) fn classify(config: &DohConfig, headers: &HeaderMap, uri: &Uri) -> DohAction {
+    if matches!(config.mode, DohMode::Off) || !is_doh_request(headers, uri, &config.extra_hosts) {
+        return DohAction::Passthrough;
+    }
+
+    match config.mode {
+        DohMode::Off => DohAction::Passthrough,
+        DohMode::Block => DohAction::Block,
+        DohMode::Redirect => match &config.upstream {
+            Some(upstream) if !upstream.is_empty() => DohAction::Redirect(upstream.clone()),
+            // Redirect configured without a usable upstream: fail safe by
+            // blocking rather than silently forwarding to the original resolver.
+            _ => DohAction::Block,
+        },
+    }
+}
+
+/// Build the outbound URL for a redirected DoH request. GET-style DoH carries
+/// the query in the URL (`?dns=` / `?name=`), so it must be preserved; POST DoH
+/// carries it in the body and needs only the upstream endpoint.
+pub(crate) fn redirect_url(upstream: &str, method: &Method, uri: &Uri) -> String {
+    if method == Method::GET {
+        if let Some(query) = uri.query() {
+            return format!("{upstream}?{query}");
+        }
+    }
+    upstream.to_string()
+}

--- a/privaxy/src/server/proxy/html_rewriter.rs
+++ b/privaxy/src/server/proxy/html_rewriter.rs
@@ -31,7 +31,21 @@ pub struct Rewriter {
     // reference to the globals they hook (setTimeout, eval, etc.), so this is
     // injected early into `<head>` rather than appended at end-of-body.
     injected_script: Option<String>,
+    // Procedural cosmetic filters (`:has-text`, `:upward`, `:xpath`, …) that
+    // can't be reduced to plain CSS. Each entry is one JSON-encoded
+    // `ProceduralOrActionFilter`; they're handed to the in-page shim injected
+    // into `<head>` alongside the scriptlets.
+    procedural_filters: Vec<String>,
+    // When set (config `debug.scriptlet_console_logging`), the empty
+    // per-scriptlet `catch` emitted by adblock-rust is rewritten to log the
+    // caught error to the page console instead of swallowing it.
+    scriptlet_debug_logging: bool,
 }
+
+/// In-page evaluator for procedural cosmetic filters. Defines the idempotent
+/// `window.__privaxyApplyProcedural(filters)` global; see the source file for
+/// the supported operators and actions.
+const PROCEDURAL_COSMETICS_SHIM: &str = include_str!("../../resources/procedural_cosmetics.js");
 
 impl Rewriter {
     pub(crate) fn new(
@@ -42,6 +56,8 @@ impl Rewriter {
         statistics: Statistics,
         csp_nonce: String,
         injected_script: Option<String>,
+        procedural_filters: Vec<String>,
+        scriptlet_debug_logging: bool,
     ) -> Self {
         Self {
             url,
@@ -52,7 +68,62 @@ impl Rewriter {
             internal_body_channel: mpsc::unbounded_channel(),
             csp_nonce,
             injected_script,
+            procedural_filters,
+            scriptlet_debug_logging,
         }
+    }
+
+    /// Combine the uBO scriptlet payload and the procedural-filter shim into a
+    /// single `<head>` script body, or `None` when there's nothing to inject.
+    /// Scriptlets come first so they hook globals before page scripts run; the
+    /// procedural shim follows and sets up its own DOM observer.
+    fn build_head_script(
+        injected_script: Option<String>,
+        procedural_filters: &[String],
+        scriptlet_debug_logging: bool,
+    ) -> Option<String> {
+        if injected_script.is_none() && procedural_filters.is_empty() {
+            return None;
+        }
+
+        let mut payload = String::new();
+
+        if let Some(mut script) = injected_script {
+            // adblock-rust isolates each scriptlet in an empty `catch ( e ) { }`.
+            // When debugging is enabled, surface what was caught rather than
+            // swallowing it (this is what hid the missing `scriptletGlobals`).
+            if scriptlet_debug_logging {
+                script = script.replace(
+                    "} catch ( e ) { }",
+                    "} catch (e) { console.error('[privaxy scriptlet]', e); }",
+                );
+            }
+            // adblock-rust emits scriptlet bodies that reference an ambient
+            // `scriptletGlobals` object — uBO supplies it in its own injection
+            // wrapper, but adblock-rust leaves that to the embedder. Without it
+            // every scriptlet hits `ReferenceError: scriptletGlobals is not
+            // defined` on its first `safeSelf()`/`shouldDebug()` call, which the
+            // scriptlet's own `try { … } catch {}` swallows — so all scriptlets
+            // silently no-op. Defining it once at the top of the payload (the
+            // scriptlet bodies use dot-access, so it must be an object)
+            // so the scriptlets actually work.
+            payload.push_str("const scriptletGlobals = {};\n");
+            payload.push_str(&script);
+        }
+
+        if !procedural_filters.is_empty() {
+            if !payload.is_empty() {
+                payload.push('\n');
+            }
+            payload.push_str(PROCEDURAL_COSMETICS_SHIM);
+            // Each filter is already valid JSON, so they're spliced straight
+            // into an array literal without re-serialization.
+            payload.push_str(";window.__privaxyApplyProcedural([");
+            payload.push_str(&procedural_filters.join(","));
+            payload.push_str("]);");
+        }
+
+        Some(payload)
     }
 
     pub(crate) fn rewrite(self) {
@@ -82,7 +153,11 @@ impl Rewriter {
 
         // Mutex<Option<_>> + take() = inject at most once even if the document
         // somehow contains multiple <head> openings.
-        let pending_script = Arc::new(Mutex::new(self.injected_script));
+        let pending_script = Arc::new(Mutex::new(Self::build_head_script(
+            self.injected_script,
+            &self.procedural_filters,
+            self.scriptlet_debug_logging,
+        )));
         let head_csp_nonce = csp_nonce.clone();
         let head_statistics = statistics.clone();
 
@@ -186,8 +261,6 @@ impl Rewriter {
                 break;
             }
             if let Some(adblock_properties) = adblock_properties {
-                let mut response_has_been_modified = false;
-
                 let blocker_result = adblock_requester
                     .get_cosmetic_response(
                         adblock_properties.url,
@@ -205,11 +278,15 @@ impl Rewriter {
                 let style_selectors: String = blocker_result
                     .style_selectors
                     .into_iter()
-                    .map(|(selector, content)| {
-                        response_has_been_modified = true;
-                        format!("{} {{ {} }}", selector, content.join(";"))
-                    })
+                    .map(|(selector, content)| format!("{} {{ {} }}", selector, content.join(";")))
                     .collect();
+
+                // Count the response as modified whenever we inject any cosmetic
+                // rules — hide selectors as well as style selectors. Previously
+                // only style selectors flipped this flag, so pages where we hid
+                // ad elements via `display: none` were undercounted.
+                let response_has_been_modified =
+                    !hidden_selectors.is_empty() || !style_selectors.is_empty();
 
                 // Scriptlets (`blocker_result.injected_script`) are intentionally
                 // ignored here: they're injected into <head> from the rewriter

--- a/privaxy/src/server/proxy/mitm.rs
+++ b/privaxy/src/server/proxy/mitm.rs
@@ -25,6 +25,7 @@ pub(crate) async fn serve_mitm_session(
     client_ip_address: IpAddr,
     local_exclusion_store: LocalExclusionStore,
     doh_config: DohConfig,
+    scriptlet_debug_logging: bool,
 ) -> Result<Response<Body>, hyper::Error> {
     let authority = match req.uri().authority().cloned() {
         Some(authority) => authority,
@@ -84,6 +85,7 @@ pub(crate) async fn serve_mitm_session(
                                             statistics.clone(),
                                             client_ip_address,
                                             doh_config.clone(),
+                                            scriptlet_debug_logging,
                                         )
                                     }),
                                 )
@@ -120,6 +122,7 @@ pub(crate) async fn serve_mitm_session(
             statistics,
             client_ip_address,
             doh_config,
+            scriptlet_debug_logging,
         )
         .await
     }

--- a/privaxy/src/server/proxy/mitm.rs
+++ b/privaxy/src/server/proxy/mitm.rs
@@ -1,5 +1,8 @@
 use super::{exclusions::LocalExclusionStore, serve::serve};
-use crate::{blocker::AdblockRequester, cert::CertCache, statistics::Statistics, Event};
+use crate::{
+    blocker::AdblockRequester, cert::CertCache, configuration::DohConfig, statistics::Statistics,
+    Event,
+};
 use http::uri::{Authority, Scheme};
 use hyper::{
     client::HttpConnector, http, server::conn::Http, service::service_fn, upgrade::Upgraded, Body,
@@ -21,6 +24,7 @@ pub(crate) async fn serve_mitm_session(
     statistics: Statistics,
     client_ip_address: IpAddr,
     local_exclusion_store: LocalExclusionStore,
+    doh_config: DohConfig,
 ) -> Result<Response<Body>, hyper::Error> {
     let authority = match req.uri().authority().cloned() {
         Some(authority) => authority,
@@ -79,6 +83,7 @@ pub(crate) async fn serve_mitm_session(
                                             broadcast_tx.clone(),
                                             statistics.clone(),
                                             client_ip_address,
+                                            doh_config.clone(),
                                         )
                                     }),
                                 )
@@ -114,6 +119,7 @@ pub(crate) async fn serve_mitm_session(
             broadcast_tx,
             statistics,
             client_ip_address,
+            doh_config,
         )
         .await
     }

--- a/privaxy/src/server/proxy/mitm.rs
+++ b/privaxy/src/server/proxy/mitm.rs
@@ -10,7 +10,11 @@ use hyper::{
 };
 use hyper_rustls::HttpsConnector;
 use std::{net::IpAddr, sync::Arc};
-use tokio::{net::TcpStream, sync::broadcast};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    net::TcpStream,
+    sync::broadcast,
+};
 use tokio_rustls::TlsAcceptor;
 
 #[allow(clippy::too_many_arguments)]
@@ -108,9 +112,35 @@ pub(crate) async fn serve_mitm_session(
         });
 
         Ok(Response::new(Body::empty()))
+    } else if local_exclusion_store.contains(authority.host())
+        && req.headers().contains_key(http::header::UPGRADE)
+    {
+        // An excluded host performing a protocol upgrade over plain HTTP — e.g.
+        // WeChat's MMTLS long-link (`http://dns.weixin.qq.com/mmtls/...`), which
+        // speaks a proprietary, non-HTTP protocol once upgraded. The hyper-based
+        // bridge in `serve` can't carry that (the upstream never returns a clean
+        // `101`, so the upgrade "expected but not completed"). Blind-tunnel the
+        // bytes at the TCP level instead, the same way excluded CONNECT hosts
+        // are tunneled.
+        tunnel_http_upgrade(req, authority).await
     } else {
         // The request is not of method `CONNECT`. Therefore,
         // this request is for an HTTP resource.
+        //
+        // An opaque (non-WebSocket) protocol upgrade to a host that is *not*
+        // excluded will be routed through `serve`, whose hyper bridge cannot
+        // carry a non-HTTP protocol — it will hang or fail. We can't safely
+        // tunnel it (the user hasn't opted the host out of filtering), so warn
+        // and let it proceed, pointing the user at the exclusion list.
+        if is_opaque_upgrade(req.headers()) {
+            log::warn!(
+                "Proxying opaque protocol-upgrade traffic (MMTLS?) for {}; \
+                 this is unlikely to work through the MITM proxy. Consider adding the host \
+                 to your exclusions.",
+                authority
+            );
+        }
+
         serve(
             adblock_requester,
             req,
@@ -128,12 +158,146 @@ pub(crate) async fn serve_mitm_session(
     }
 }
 
-async fn tunnel(mut upgraded: &mut Upgraded, authority: &Authority) -> std::io::Result<()> {
-    let mut server = TcpStream::connect(authority.to_string()).await?;
+/// An HTTP `Upgrade` request whose target protocol is something other than
+/// WebSocket (or h2c) — e.g. WeChat's MMTLS long-link. The proxy can't do
+/// anything useful with such a protocol, and its hyper-based upgrade bridge
+/// can't carry it; these are only handled correctly by blind-tunneling, which
+/// requires the host to be excluded.
+fn is_opaque_upgrade(headers: &http::HeaderMap) -> bool {
+    headers
+        .get(http::header::UPGRADE)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            // The Upgrade header may list multiple comma-separated tokens, each
+            // optionally `name/version`. Treat it as opaque only if no token is
+            // a protocol we can actually bridge.
+            value.split(',').all(|token| {
+                let name = token.trim().split('/').next().unwrap_or("").trim();
+                !name.eq_ignore_ascii_case("websocket") && !name.eq_ignore_ascii_case("h2c")
+            })
+        })
+        .unwrap_or(false)
+}
 
-    tokio::io::copy_bidirectional(&mut upgraded, &mut server).await?;
+/// Blind-tunnel a plain-HTTP protocol upgrade to an excluded host. The proxied
+/// request carries an absolute-form URI; we replay it to the upstream in
+/// origin-form over a raw socket, return our own `101` to the client, and pipe
+/// the (opaque) post-upgrade bytes both ways. The upstream's own `101` header
+/// block is discarded so the client sees exactly one status line.
+///
+/// thank you, wechat, for making this necessary
+async fn tunnel_http_upgrade(
+    req: Request<Body>,
+    authority: Authority,
+) -> Result<Response<Body>, hyper::Error> {
+    // Build the origin-form request head before `req` is moved into the task.
+    let path = req
+        .uri()
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or("/");
+    let mut head = format!("{} {} HTTP/1.1\r\n", req.method(), path);
+    for (name, value) in req.headers() {
+        head.push_str(name.as_str());
+        head.push_str(": ");
+        // Header values are effectively always ASCII here; lossy conversion just
+        // avoids failing the replay on a pathological non-UTF8 value.
+        head.push_str(&String::from_utf8_lossy(value.as_bytes()));
+        head.push_str("\r\n");
+    }
+    head.push_str("\r\n");
+
+    let upgrade_value = req.headers().get(http::header::UPGRADE).cloned();
+
+    // The bridge runs detached: `hyper::upgrade::on` only resolves once we have
+    // returned the `101` below, so awaiting it here would deadlock.
+    tokio::spawn(async move {
+        match bridge_http_upgrade(req, head, &authority).await {
+            Ok(()) => log::debug!("HTTP-upgrade tunnel closed for {}", authority),
+            Err(e) => log::warn!("HTTP-upgrade tunnel for {} failed: {}", authority, e),
+        }
+    });
+
+    let mut response = Response::new(Body::empty());
+    *response.status_mut() = http::StatusCode::SWITCHING_PROTOCOLS;
+    response.headers_mut().insert(
+        http::header::CONNECTION,
+        http::HeaderValue::from_static("upgrade"),
+    );
+    if let Some(upgrade) = upgrade_value {
+        response
+            .headers_mut()
+            .insert(http::header::UPGRADE, upgrade);
+    }
+    Ok(response)
+}
+
+/// Upstream half of `tunnel_http_upgrade`: wait for the client upgrade, connect
+/// to the origin, replay the request head, strip the origin's `101`, then pipe.
+async fn bridge_http_upgrade(
+    req: Request<Body>,
+    head: String,
+    authority: &Authority,
+) -> std::io::Result<()> {
+    let host = authority.host();
+    // Proxied `http://` authorities carry no port; default to 80.
+    let port = authority.port_u16().unwrap_or(80);
+
+    let mut client = hyper::upgrade::on(req)
+        .await
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let mut upstream = TcpStream::connect((host, port)).await?;
+    upstream.write_all(head.as_bytes()).await?;
+
+    let leftover = read_past_response_headers(&mut upstream).await?;
+    if !leftover.is_empty() {
+        client.write_all(&leftover).await?;
+    }
+
+    pipe(&mut client, &mut upstream).await
+}
+
+/// Read from `stream` until the end of the HTTP response header block
+/// (`\r\n\r\n`) and return any bytes that followed it (the start of the tunneled
+/// payload). If the upstream closes or never sends a recognizable header block,
+/// whatever was read is returned so it can still be forwarded.
+async fn read_past_response_headers(stream: &mut TcpStream) -> std::io::Result<Vec<u8>> {
+    const HEADER_CAP: usize = 64 * 1024;
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 1024];
+
+    loop {
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            return Ok(buf);
+        }
+        buf.extend_from_slice(&chunk[..n]);
+
+        if let Some(pos) = buf.windows(4).position(|window| window == b"\r\n\r\n") {
+            return Ok(buf.split_off(pos + 4));
+        }
+        if buf.len() > HEADER_CAP {
+            // No header terminator in a sane amount of data; treat everything as
+            // payload rather than stalling.
+            return Ok(buf);
+        }
+    }
+}
+
+async fn tunnel(upgraded: &mut Upgraded, authority: &Authority) -> std::io::Result<()> {
+    let mut server = TcpStream::connect(authority.to_string()).await?;
 
     log::debug!("Started tunneling host: {}", authority);
 
+    pipe(upgraded, &mut server).await
+}
+
+/// Pipe two duplex streams in both directions until either side closes.
+async fn pipe<A, B>(a: &mut A, b: &mut B) -> std::io::Result<()>
+where
+    A: AsyncRead + AsyncWrite + Unpin + ?Sized,
+    B: AsyncRead + AsyncWrite + Unpin + ?Sized,
+{
+    tokio::io::copy_bidirectional(a, b).await?;
     Ok(())
 }

--- a/privaxy/src/server/proxy/mod.rs
+++ b/privaxy/src/server/proxy/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod doh;
 pub(crate) mod mitm;
 pub(crate) mod serve;
 pub(crate) use mitm::serve_mitm_session;

--- a/privaxy/src/server/proxy/serve.rs
+++ b/privaxy/src/server/proxy/serve.rs
@@ -257,6 +257,7 @@ pub(crate) async fn serve(
     statistics: Statistics,
     client_ip_address: IpAddr,
     doh_config: DohConfig,
+    scriptlet_debug_logging: bool,
 ) -> Result<Response<Body>, hyper::Error> {
     let scheme_string = scheme.to_string();
 
@@ -451,14 +452,14 @@ pub(crate) async fn serve(
     if is_html {
         let (sender_rewriter, receiver_rewriter) = crossbeam_channel::unbounded::<Bytes>();
 
-        // Resolve the URL-scoped scriptlet payload up-front so the rewriter can
-        // prepend it inside <head> before any page scripts execute. The
-        // end-of-body cosmetic lookup still runs for hide/style selectors,
-        // which depend on collected IDs/classes.
-        let injected_script = adblock_requester
+        // Resolve the URL-scoped payloads up-front so the rewriter can prepend
+        // them inside <head> before any page scripts execute: the uBO scriptlet
+        // and the procedural cosmetic filters (both URL-specific, not dependent
+        // on collected IDs/classes). The end-of-body cosmetic lookup still runs
+        // for hide/style selectors, which do depend on collected IDs/classes.
+        let head_cosmetics = adblock_requester
             .get_cosmetic_response(match_url.clone(), Vec::new(), Vec::new())
-            .await
-            .injected_script;
+            .await;
 
         let rewriter = Rewriter::new(
             match_url.clone(),
@@ -467,7 +468,9 @@ pub(crate) async fn serve(
             sender,
             statistics,
             csp_nonce.expect("csp_nonce is Some whenever is_html"),
-            injected_script,
+            head_cosmetics.injected_script,
+            head_cosmetics.procedural_filters,
+            scriptlet_debug_logging,
         );
 
         tokio::task::spawn_blocking(|| rewriter.rewrite());

--- a/privaxy/src/server/proxy/serve.rs
+++ b/privaxy/src/server/proxy/serve.rs
@@ -554,10 +554,14 @@ async fn perform_two_ends_upgrade(
 ) -> Response<Body> {
     let (mut duplex_client, mut duplex_server) = tokio::io::duplex(32);
 
+    // Captured for log context; `uri` is moved into `new_request` below.
+    let request_uri = uri.to_string();
+
     let mut new_request = Request::new(Body::empty());
     *new_request.headers_mut() = request.headers().clone();
     *new_request.uri_mut() = uri;
 
+    let client_uri = request_uri.clone();
     tokio::spawn(async move {
         match hyper::upgrade::on(request).await {
             Ok(mut upgraded_client) => {
@@ -565,15 +569,40 @@ async fn perform_two_ends_upgrade(
                     tokio::io::copy_bidirectional(&mut upgraded_client, &mut duplex_client).await;
             }
             Err(e) => {
-                log::debug!("Unable to upgrade: {}", e)
+                log::warn!(
+                    "Unable to upgrade client connection for {}: {}",
+                    client_uri,
+                    e
+                )
             }
         }
     });
 
     let response = match hyper_client.request(new_request).await {
         Ok(response) => response,
-        Err(_err) => return get_empty_response(http::StatusCode::BAD_REQUEST),
+        Err(err) => {
+            log::warn!(
+                "Upstream upgrade request failed for {}: {}",
+                request_uri,
+                err
+            );
+            return get_empty_response(http::StatusCode::BAD_GATEWAY);
+        }
     };
+
+    // Only bridge a genuine protocol switch. If the upstream did not return
+    // `101 Switching Protocols`, forwarding a fabricated 101 leaves the client
+    // believing the upgrade succeeded while no bytes are ever bridged from the
+    // server half — the connection then hangs forever. Forward the upstream's
+    // actual response instead so the client can fail (or follow it) cleanly.
+    if response.status() != StatusCode::SWITCHING_PROTOCOLS {
+        log::warn!(
+            "Upstream did not upgrade {} (status {}); forwarding response as-is",
+            request_uri,
+            response.status()
+        );
+        return response;
+    }
 
     let mut new_response = get_empty_response(StatusCode::SWITCHING_PROTOCOLS);
     *new_response.headers_mut() = response.headers().clone();
@@ -586,7 +615,11 @@ async fn perform_two_ends_upgrade(
             });
         }
         Err(e) => {
-            log::debug!("Unable to upgrade: {}", e)
+            log::warn!(
+                "Unable to upgrade upstream connection for {}: {}",
+                request_uri,
+                e
+            )
         }
     }
 

--- a/privaxy/src/server/proxy/serve.rs
+++ b/privaxy/src/server/proxy/serve.rs
@@ -13,9 +13,14 @@ use hyper_rustls::HttpsConnector;
 use std::net::IpAddr;
 use tokio::sync::broadcast;
 
-const CSP_HEADERS: [&str; 4] = [
+// Only *enforcing* CSP headers are augmented. Report-only headers
+// (`content-security-policy-report-only`) are deliberately left untouched:
+// they never block our injected script/style, so augmenting them buys nothing,
+// and doing so would inject our nonce into the site's own violation telemetry
+// and suppress reports the site author relies on (e.g. while testing a strict
+// policy before enforcing it).
+const CSP_HEADERS: [&str; 3] = [
     "content-security-policy",
-    "content-security-policy-report-only",
     "x-content-security-policy",
     "x-webkit-csp",
 ];
@@ -178,6 +183,66 @@ fn augment_csp_value(value: &str, nonce: &str) -> String {
         .join("; ")
 }
 
+/// Map an outgoing request's headers to the adblock-rust request-type string
+/// the engine expects (the same vocabulary as uBO's `$type` options). Without
+/// an accurate type, type-scoped filter and exception rules — e.g. the
+/// `$script`/`$xmlhttprequest` exceptions in uBO's unbreak lists that keep
+/// sites like DuckDuckGo working — match incorrectly and cause false blocks.
+///
+/// Modern browsers send `Sec-Fetch-Dest`, which maps cleanly onto these types.
+/// When it's absent we fall back to sniffing `Accept`, and finally to `other`.
+fn request_type_from_headers(headers: &HeaderMap) -> &'static str {
+    if let Some(dest) = headers.get("sec-fetch-dest").and_then(|v| v.to_str().ok()) {
+        return match dest {
+            "document" => "document",
+            "frame" | "iframe" => "sub_frame",
+            "script" | "serviceworker" | "sharedworker" | "worker" | "audioworklet"
+            | "paintworklet" => "script",
+            "style" => "stylesheet",
+            "image" => "image",
+            "font" => "font",
+            "audio" | "video" | "track" => "media",
+            "object" | "embed" => "object",
+            "report" => "ping",
+            // `empty` is what fetch()/XHR report; treat it as xhr.
+            "empty" | "" => "xmlhttprequest",
+            _ => "other",
+        };
+    }
+
+    match headers
+        .get(http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(accept) if accept.contains("text/html") => "document",
+        Some(accept) if accept.contains("text/css") => "stylesheet",
+        Some(accept) if accept.contains("image/") => "image",
+        Some(accept) if accept.contains("javascript") || accept.contains("ecmascript") => "script",
+        _ => "other",
+    }
+}
+
+/// adblock-rust matches against the literal URL string, so an explicit default
+/// port (`:443` for https, `:80` for http) wedges itself between the host and the
+/// path and breaks hostname-anchored rules (`||host/path`) — the path no longer
+/// follows the host directly. Browsers and uBO match on the canonical URL with
+/// the default port stripped, so we normalise the same way before handing URLs to
+/// the blocker/cosmetic engine. Non-default ports are preserved.
+fn url_for_matching(uri: &Uri) -> String {
+    let scheme = uri.scheme_str().unwrap_or("https");
+    let host = uri.host().unwrap_or("");
+    let path = uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/");
+    let default_port = match scheme {
+        "https" => Some(443),
+        "http" => Some(80),
+        _ => None,
+    };
+    match uri.port_u16() {
+        Some(port) if Some(port) != default_port => format!("{scheme}://{host}:{port}{path}"),
+        _ => format!("{scheme}://{host}{path}"),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn serve(
     adblock_requester: AdblockRequester,
@@ -222,15 +287,23 @@ pub(crate) async fn serve(
 
     statistics.increment_top_clients(client_ip_address);
 
+    let request_type = request_type_from_headers(req.headers()).to_string();
+
+    // Canonical URL (default port stripped) for all adblock-engine matching —
+    // see `url_for_matching`. The raw `uri` (which may carry `:443`) is still
+    // used for the actual outbound request below.
+    let match_url = url_for_matching(&uri);
+
     let (is_request_blocked, blocker_result) = adblock_requester
         .is_network_url_blocked(
-            uri.to_string(),
+            match_url.clone(),
             match req.headers().get(http::header::REFERER) {
                 Some(referer) => referer.to_str().unwrap().to_string(),
                 // When no referer, we default to `uri` as we otherwise may get many false
                 // positives due to the blocker thinking it's third party requests.
-                None => uri.to_string(),
+                None => match_url.clone(),
             },
+            request_type.clone(),
         )
         .await;
 
@@ -250,7 +323,20 @@ pub(crate) async fn serve(
             uri.path()
         ));
 
-        log::debug!("Blocked request: {}", uri);
+        // adblock-rust fuses many same-option patterns into one filter and
+        // reports the union as the matched filter, which can be enormous; cap
+        // it so debug logs stay readable.
+        let matched_filter = blocker_result.filter.as_deref().unwrap_or("<none>");
+        let matched_filter = match matched_filter.char_indices().nth(200) {
+            Some((idx, _)) => format!("{}… (truncated)", &matched_filter[..idx]),
+            None => matched_filter.to_string(),
+        };
+        log::debug!(
+            "Blocked request: {} [type={}] matched filter: {}",
+            uri,
+            request_type,
+            matched_filter
+        );
 
         return Ok(get_blocked_by_privaxy_response(blocker_result));
     }
@@ -341,12 +427,12 @@ pub(crate) async fn serve(
         // end-of-body cosmetic lookup still runs for hide/style selectors,
         // which depend on collected IDs/classes.
         let injected_script = adblock_requester
-            .get_cosmetic_response(uri.to_string(), Vec::new(), Vec::new())
+            .get_cosmetic_response(match_url.clone(), Vec::new(), Vec::new())
             .await
             .injected_script;
 
         let rewriter = Rewriter::new(
-            uri.to_string(),
+            match_url.clone(),
             adblock_requester,
             receiver_rewriter,
             sender,

--- a/privaxy/src/server/proxy/serve.rs
+++ b/privaxy/src/server/proxy/serve.rs
@@ -1,5 +1,7 @@
+use super::doh::{self, DohAction};
 use super::html_rewriter::Rewriter;
 use crate::blocker::AdblockRequester;
+use crate::configuration::DohConfig;
 use crate::statistics::Statistics;
 use crate::web_gui::events::Event;
 use adblock::blocker::BlockerResult;
@@ -254,6 +256,7 @@ pub(crate) async fn serve(
     broadcast_sender: broadcast::Sender<Event>,
     statistics: Statistics,
     client_ip_address: IpAddr,
+    doh_config: DohConfig,
 ) -> Result<Response<Body>, hyper::Error> {
     let scheme_string = scheme.to_string();
 
@@ -293,6 +296,21 @@ pub(crate) async fn serve(
     // see `url_for_matching`. The raw `uri` (which may carry `:443`) is still
     // used for the actual outbound request below.
     let match_url = url_for_matching(&uri);
+
+    // DNS-over-HTTPS policy is applied before adblock matching: a DoH endpoint
+    // rarely matches a network rule, but we still want to refuse or redirect it.
+    let doh_action = doh::classify(&doh_config, req.headers(), &uri);
+    if let DohAction::Block = &doh_action {
+        log::debug!("Refusing DoH request: {}", uri);
+        let _result = broadcast_sender.send(Event {
+            now: chrono::Utc::now(),
+            method: req.method().to_string(),
+            url: req.uri().to_string(),
+            is_request_blocked: true,
+        });
+        statistics.increment_blocked_requests();
+        return Ok(get_empty_response(StatusCode::BAD_GATEWAY));
+    }
 
     let (is_request_blocked, blocker_result) = adblock_requester
         .is_network_url_blocked(
@@ -370,8 +388,19 @@ pub(crate) async fn serve(
             }
         }
     }
+    // In redirect mode the query is forwarded to the configured upstream
+    // resolver instead of the endpoint the client chose; otherwise the original
+    // URL is used unchanged.
+    let outbound_url = match &doh_action {
+        DohAction::Redirect(upstream) => {
+            log::debug!("Redirecting DoH request to {}: {}", upstream, uri);
+            doh::redirect_url(upstream, req.method(), &uri)
+        }
+        _ => req.uri().to_string(),
+    };
+
     let mut response = match client
-        .request(req.method().clone(), req.uri().to_string())
+        .request(req.method().clone(), outbound_url)
         .headers(request_headers)
         .body(req.into_body())
         .send()

--- a/privaxy/src/server/statistics.rs
+++ b/privaxy/src/server/statistics.rs
@@ -110,7 +110,6 @@ impl Statistics {
                 let mut top_clients_iter = top_clients.iter();
 
                 let mut top_clients = (0..=ENTRIES_PER_STATISTICS_TABLE)
-                    .into_iter()
                     .filter_map(|_| {
                         let (ipv4, count) = top_clients_iter.next()?;
 

--- a/privaxy/src/server/web_gui/auth/routes.rs
+++ b/privaxy/src/server/web_gui/auth/routes.rs
@@ -156,11 +156,33 @@ async fn get_status(
         (false, None)
     };
 
-    Ok(Box::new(warp::reply::json(&AuthStatusResponse {
+    let body = serde_json::to_string(&AuthStatusResponse {
         authenticated,
         setup_required,
         username,
-    })))
+    })
+    .unwrap();
+    let mut response = Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "application/json");
+
+    // If the caller presented a session cookie that did not authenticate them
+    // (expired, signed with a rotated key, or otherwise stale), clear it from
+    // the browser.
+    if !authenticated && has_invalid_session_cookie(&configuration, &cookie) {
+        response = response.header("Set-Cookie", build_logout_cookie(configuration.network.tls));
+    }
+
+    Ok(Box::new(response.body(body).unwrap()))
+}
+
+/// Returns true when a `privaxy_session` cookie is present but fails
+/// verification against the current signing key.
+fn has_invalid_session_cookie(configuration: &Configuration, cookie: &Option<String>) -> bool {
+    match cookie.as_deref().and_then(extract_session_cookie) {
+        Some(token) => verify(&token, &configuration.auth.session_signing_key).is_err(),
+        None => false,
+    }
 }
 
 async fn post_setup(

--- a/privaxy/src/server/web_gui/blocking_enabled.rs
+++ b/privaxy/src/server/web_gui/blocking_enabled.rs
@@ -18,7 +18,7 @@ pub async fn put_blocking_enabled(
     blocking_enabled: BlockingEnabled,
     blocking_disabled_store: BlockingDisabledStore,
 ) -> Result<impl warp::Reply, Infallible> {
-    blocking_disabled_store.set(!blocking_enabled.0);
+    blocking_disabled_store.set(blocking_enabled.0);
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/privaxy/src/server/web_gui/filters.rs
+++ b/privaxy/src/server/web_gui/filters.rs
@@ -1,5 +1,7 @@
 use super::get_error_response;
-use crate::configuration::{calc_filter_filename, Configuration, Filter, FilterGroup};
+use crate::configuration::{
+    calc_filter_filename, Configuration, ConfigurationError, Filter, FilterGroup,
+};
 use crate::web_gui::ApiError;
 use serde::Deserialize;
 use serde_with::{serde_as, DisplayFromStr};
@@ -119,7 +121,7 @@ async fn add_filter(
         url: filter_url,
         title: filter_request.title.clone(),
         group: filter_request.group,
-        file_name: calc_filter_filename(&filter_request.url.to_string()),
+        file_name: calc_filter_filename(filter_request.url.as_ref()),
     };
 
     match configuration
@@ -127,6 +129,14 @@ async fn add_filter(
         .await
     {
         Ok(_) => {}
+        Err(ConfigurationError::FilterValidationError(message)) => {
+            log::warn!("Rejected invalid filter: {message}");
+            return Ok(Response::builder()
+                .status(http::StatusCode::UNPROCESSABLE_ENTITY)
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(serde_json::to_string(&ApiError { error: message }).unwrap())
+                .unwrap());
+        }
         Err(err) => {
             log::error!("Failed to add filter: {err}");
             return Ok(get_error_response(err));

--- a/privaxy/src/server/web_gui/logs.rs
+++ b/privaxy/src/server/web_gui/logs.rs
@@ -1,0 +1,39 @@
+use crate::logging::LogHandle;
+use futures::{SinkExt, StreamExt};
+use tokio::sync::broadcast::error::RecvError;
+use warp::ws::{Message, WebSocket};
+
+pub(super) async fn logs(websocket: WebSocket, log_handle: LogHandle) {
+    let mut receiver = log_handle.sender.subscribe();
+
+    let (mut tx, mut rx) = websocket.split();
+
+    // To handle Ping / Pong messages
+    tokio::spawn(async move { while let Some(_message) = rx.next().await {} });
+
+    // Prime the client with recently retained records so the view isn't empty
+    // until the next record is emitted.
+    for entry in log_handle.backlog_snapshot() {
+        let message = Message::text(serde_json::to_string(&entry).unwrap());
+
+        if tx.send(message).await.is_err() {
+            return;
+        }
+    }
+
+    loop {
+        match receiver.recv().await {
+            Ok(entry) => {
+                let message = Message::text(serde_json::to_string(&entry).unwrap());
+
+                if tx.send(message).await.is_err() {
+                    break;
+                }
+            }
+            // The subscriber fell behind and the channel dropped records; keep
+            // streaming from the most recent retained record.
+            Err(RecvError::Lagged(_)) => continue,
+            Err(RecvError::Closed) => break,
+        }
+    }
+}

--- a/privaxy/src/server/web_gui/mod.rs
+++ b/privaxy/src/server/web_gui/mod.rs
@@ -1,3 +1,4 @@
+use crate::logging::LogHandle;
 use crate::proxy::exclusions::LocalExclusionStore;
 use crate::statistics::Statistics;
 use crate::WEBAPP_FRONTEND_DIR;
@@ -18,6 +19,7 @@ pub(crate) mod events;
 pub(crate) mod exclusions;
 mod filterlists;
 pub(crate) mod filters;
+pub(crate) mod logs;
 mod pac;
 pub(crate) mod settings;
 pub(crate) mod statistics;
@@ -34,6 +36,7 @@ pub(crate) fn get_frontend(
     configuration_save_lock: &Arc<tokio::sync::Mutex<()>>,
     local_exclusions_store: &LocalExclusionStore,
     notify_reload: Arc<Notify>,
+    log_handle: LogHandle,
 ) -> BoxedFilter<(impl warp::Reply,)> {
     let static_files_routes = create_static_routes();
 
@@ -57,6 +60,7 @@ pub(crate) fn get_frontend(
         local_exclusions_store,
         http_client,
         notify_reload,
+        log_handle,
     );
 
     let pac_route = pac::create_routes(configuration_save_lock.clone());
@@ -106,6 +110,7 @@ fn create_api_routes(
     local_exclusions_store: &LocalExclusionStore,
     http_client: reqwest::Client,
     notify_reload: Arc<Notify>,
+    log_handle: LogHandle,
 ) -> BoxedFilter<(impl Reply,)> {
     let def_headers =
         warp::filters::reply::default_header(http::header::CONTENT_TYPE, "application/json");
@@ -132,6 +137,15 @@ fn create_api_routes(
         .map(move |ws: warp::ws::Ws| {
             let statistics = statistics.clone();
             ws.on_upgrade(move |websocket| statistics::statistics(websocket, statistics))
+        });
+
+    let logs_handle = log_handle.clone();
+    let logs_route = warp::path("logs")
+        .and(require_auth.clone())
+        .and(warp::ws())
+        .map(move |ws: warp::ws::Ws| {
+            let log_handle = logs_handle.clone();
+            ws.on_upgrade(move |websocket| logs::logs(websocket, log_handle))
         });
 
     let filters_route =
@@ -167,6 +181,7 @@ fn create_api_routes(
                 configuration_updater_sender.clone(),
                 configuration_save_lock.clone(),
                 notify_reload.clone(),
+                log_handle.clone(),
             ));
 
     let blocking_enabled_route = warp::path("blocking-enabled")
@@ -189,6 +204,7 @@ fn create_api_routes(
     let api_inner = auth_routes
         .or(events_route)
         .or(statistics_route)
+        .or(logs_route)
         .or(filters_route)
         .or(custom_filters_route)
         .or(exclusions_route)

--- a/privaxy/src/server/web_gui/settings/ca_certificate.rs
+++ b/privaxy/src/server/web_gui/settings/ca_certificate.rs
@@ -50,7 +50,7 @@ async fn validate_ca_certificates(body: Ca) -> Result<Box<dyn warp::Reply>, Infa
         )),
         Err(err) => {
             log::error!("Invalid CA certificates: {err}");
-            return Ok(Box::new(
+            Ok(Box::new(
                 Response::builder()
                     .status(http::StatusCode::BAD_REQUEST)
                     .body(
@@ -59,7 +59,7 @@ async fn validate_ca_certificates(body: Ca) -> Result<Box<dyn warp::Reply>, Infa
                         })
                         .unwrap(),
                     ),
-            ));
+            ))
         }
     }
 }

--- a/privaxy/src/server/web_gui/settings/debug.rs
+++ b/privaxy/src/server/web_gui/settings/debug.rs
@@ -1,5 +1,6 @@
 use super::get_error_response;
 use crate::configuration::{Configuration, DebugConfig};
+use crate::logging::LogHandle;
 use crate::web_gui::with_configuration_save_lock;
 use crate::web_gui::with_configuration_updater_sender;
 use crate::web_gui::with_notify_reload;
@@ -10,6 +11,12 @@ use tokio::sync::Notify;
 use warp::filters::BoxedFilter;
 use warp::http::Response;
 use warp::Filter as RouteFilter;
+
+fn with_log_handle(
+    log_handle: LogHandle,
+) -> impl RouteFilter<Extract = (LogHandle,), Error = Infallible> + Clone {
+    warp::any().map(move || log_handle.clone())
+}
 
 async fn get_debug_settings() -> Result<Box<dyn warp::Reply>, Infallible> {
     log::debug!("Getting debug settings");
@@ -28,6 +35,7 @@ async fn put_debug_settings(
     configuration_updater_sender: Sender<Configuration>,
     configuration_save_lock: Arc<tokio::sync::Mutex<()>>,
     notify_reload: Arc<Notify>,
+    log_handle: LogHandle,
 ) -> Result<Box<dyn warp::Reply>, Infallible> {
     let guard = configuration_save_lock.lock().await;
     let mut configuration = match Configuration::read_from_home().await {
@@ -37,6 +45,12 @@ async fn put_debug_settings(
             return Ok(Box::new(get_error_response(err)));
         }
     };
+
+    // The log level is applied live below, but the proxy only reads
+    // `scriptlet_console_logging` when it (re)starts, so only that toggle
+    // warrants the disruptive reload.
+    let scriptlet_logging_changed =
+        configuration.debug.scriptlet_console_logging != debug_settings.scriptlet_console_logging;
 
     configuration.debug = debug_settings;
 
@@ -51,9 +65,15 @@ async fn put_debug_settings(
         .unwrap();
     drop(guard);
 
-    // The proxy reads `debug.scriptlet_console_logging` when it (re)starts, so a
-    // reload is what makes the toggle take effect on newly served pages.
-    notify_reload.notify_waiters();
+    // Apply the log level immediately rather than waiting for the next
+    // process restart; verbosity is governed by the live atomic in LogHandle.
+    log_handle.set_level(configuration.debug.log_level.to_level_filter());
+
+    // Avoid bouncing the proxy/frontend (and dropping live connections) for a
+    // log-level-only change, which already took effect above.
+    if scriptlet_logging_changed {
+        notify_reload.notify_waiters();
+    }
 
     Ok(Box::new(
         Response::builder()
@@ -66,6 +86,7 @@ pub(super) fn create_routes(
     configuration_updater_sender: Sender<Configuration>,
     configuration_save_lock: Arc<tokio::sync::Mutex<()>>,
     notify_reload: Arc<Notify>,
+    log_handle: LogHandle,
 ) -> BoxedFilter<(impl warp::Reply,)> {
     let get_route = warp::get()
         .and(warp::path::end())
@@ -81,6 +102,7 @@ pub(super) fn create_routes(
             configuration_save_lock.clone(),
         ))
         .and(with_notify_reload(notify_reload.clone()))
+        .and(with_log_handle(log_handle))
         .and_then(put_debug_settings);
 
     get_route.or(put_route).boxed()

--- a/privaxy/src/server/web_gui/settings/debug.rs
+++ b/privaxy/src/server/web_gui/settings/debug.rs
@@ -1,0 +1,87 @@
+use super::get_error_response;
+use crate::configuration::{Configuration, DebugConfig};
+use crate::web_gui::with_configuration_save_lock;
+use crate::web_gui::with_configuration_updater_sender;
+use crate::web_gui::with_notify_reload;
+use std::convert::Infallible;
+use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::Notify;
+use warp::filters::BoxedFilter;
+use warp::http::Response;
+use warp::Filter as RouteFilter;
+
+async fn get_debug_settings() -> Result<Box<dyn warp::Reply>, Infallible> {
+    log::debug!("Getting debug settings");
+    let configuration = match Configuration::read_from_home().await {
+        Ok(configuration) => configuration,
+        Err(err) => {
+            log::error!("Failed to read debug settings: {err}");
+            return Ok(Box::new(get_error_response(err)));
+        }
+    };
+    Ok(Box::new(warp::reply::json(&configuration.debug)))
+}
+
+async fn put_debug_settings(
+    debug_settings: DebugConfig,
+    configuration_updater_sender: Sender<Configuration>,
+    configuration_save_lock: Arc<tokio::sync::Mutex<()>>,
+    notify_reload: Arc<Notify>,
+) -> Result<Box<dyn warp::Reply>, Infallible> {
+    let guard = configuration_save_lock.lock().await;
+    let mut configuration = match Configuration::read_from_home().await {
+        Ok(configuration) => configuration,
+        Err(err) => {
+            log::error!("Failed to read configuration for debug update: {err}");
+            return Ok(Box::new(get_error_response(err)));
+        }
+    };
+
+    configuration.debug = debug_settings;
+
+    if let Err(err) = configuration.save().await {
+        log::error!("Failed to save debug settings: {err}");
+        drop(guard);
+        return Ok(Box::new(get_error_response(err)));
+    }
+    configuration_updater_sender
+        .send(configuration.clone())
+        .await
+        .unwrap();
+    drop(guard);
+
+    // The proxy reads `debug.scriptlet_console_logging` when it (re)starts, so a
+    // reload is what makes the toggle take effect on newly served pages.
+    notify_reload.notify_waiters();
+
+    Ok(Box::new(
+        Response::builder()
+            .status(http::StatusCode::NO_CONTENT)
+            .body("".to_string()),
+    ))
+}
+
+pub(super) fn create_routes(
+    configuration_updater_sender: Sender<Configuration>,
+    configuration_save_lock: Arc<tokio::sync::Mutex<()>>,
+    notify_reload: Arc<Notify>,
+) -> BoxedFilter<(impl warp::Reply,)> {
+    let get_route = warp::get()
+        .and(warp::path::end())
+        .and_then(get_debug_settings);
+
+    let put_route = warp::put()
+        .and(warp::path::end())
+        .and(warp::body::json())
+        .and(with_configuration_updater_sender(
+            configuration_updater_sender.clone(),
+        ))
+        .and(with_configuration_save_lock(
+            configuration_save_lock.clone(),
+        ))
+        .and(with_notify_reload(notify_reload.clone()))
+        .and_then(put_debug_settings);
+
+    get_route.or(put_route).boxed()
+}

--- a/privaxy/src/server/web_gui/settings/mod.rs
+++ b/privaxy/src/server/web_gui/settings/mod.rs
@@ -1,5 +1,6 @@
 use super::get_error_response;
 use crate::configuration::Configuration;
+use crate::logging::LogHandle;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::Notify;
@@ -15,6 +16,7 @@ pub(crate) fn create_routes(
     configuration_updater_sender: Sender<Configuration>,
     configuration_save_lock: Arc<tokio::sync::Mutex<()>>,
     notify_reload: Arc<Notify>,
+    log_handle: LogHandle,
 ) -> BoxedFilter<(impl warp::Reply,)> {
     let network_settings_route = warp::path("network").and(network::create_routes(
         configuration_updater_sender.clone(),
@@ -38,6 +40,7 @@ pub(crate) fn create_routes(
         configuration_updater_sender.clone(),
         configuration_save_lock.clone(),
         notify_reload.clone(),
+        log_handle,
     ));
 
     network_settings_route

--- a/privaxy/src/server/web_gui/settings/mod.rs
+++ b/privaxy/src/server/web_gui/settings/mod.rs
@@ -7,6 +7,7 @@ use warp::filters::BoxedFilter;
 use warp::Filter as RouteFilter;
 
 mod ca_certificate;
+mod debug;
 mod network;
 mod pac;
 
@@ -33,8 +34,15 @@ pub(crate) fn create_routes(
         notify_reload.clone(),
     ));
 
+    let debug_settings_route = warp::path("debug").and(debug::create_routes(
+        configuration_updater_sender.clone(),
+        configuration_save_lock.clone(),
+        notify_reload.clone(),
+    ));
+
     network_settings_route
         .or(ca_cert_route)
         .or(pac_settings_route)
+        .or(debug_settings_route)
         .boxed()
 }

--- a/privaxy/src/server/web_gui/settings/network.rs
+++ b/privaxy/src/server/web_gui/settings/network.rs
@@ -33,13 +33,13 @@ pub struct NetworkConfigRequest {
     pub doh: Option<DohConfig>,
 }
 
-impl Into<NetworkConfig> for NetworkConfigRequest {
-    fn into(self) -> NetworkConfig {
+impl From<NetworkConfigRequest> for NetworkConfig {
+    fn from(val: NetworkConfigRequest) -> Self {
         NetworkConfig {
-            bind_addr: self.bind_addr,
-            proxy_port: self.proxy_port,
-            web_port: self.web_port,
-            tls: self.tls,
+            bind_addr: val.bind_addr,
+            proxy_port: val.proxy_port,
+            web_port: val.web_port,
+            tls: val.tls,
             tls_cert_path: None,
             tls_key_path: None,
             listen_url: None,

--- a/privaxy/src/server/web_gui/settings/network.rs
+++ b/privaxy/src/server/web_gui/settings/network.rs
@@ -1,6 +1,6 @@
 use super::get_error_response;
 use crate::configuration;
-use crate::configuration::NetworkConfig;
+use crate::configuration::{DohConfig, NetworkConfig};
 use crate::web_gui::with_configuration_save_lock;
 use crate::web_gui::with_configuration_updater_sender;
 use crate::web_gui::with_notify_reload;
@@ -27,6 +27,10 @@ pub struct NetworkConfigRequest {
     pub web_port: u16,
     /// Enable TLS for the web server.
     pub tls: bool,
+    /// DNS-over-HTTPS interception policy. Omitted by older clients, in which
+    /// case the current configuration is preserved.
+    #[serde(default)]
+    pub doh: Option<DohConfig>,
 }
 
 impl Into<NetworkConfig> for NetworkConfigRequest {
@@ -44,6 +48,7 @@ impl Into<NetworkConfig> for NetworkConfigRequest {
             pac_direct_ips: Vec::new(),
             pac_direct_cidrs: std::collections::BTreeMap::new(),
             pac_direct_fqdns: Vec::new(),
+            doh: DohConfig::default(),
         }
     }
 }
@@ -76,6 +81,7 @@ async fn put_network_settings(
     };
 
     drop(lock);
+    let requested_doh = network_settings.doh.clone();
     let mut net_cfg: NetworkConfig = network_settings.into();
     let current_cfg = configuration.network.clone();
     net_cfg.tls_cert_path = current_cfg.tls_cert_path;
@@ -86,6 +92,7 @@ async fn put_network_settings(
     net_cfg.pac_direct_ips = current_cfg.pac_direct_ips;
     net_cfg.pac_direct_cidrs = current_cfg.pac_direct_cidrs;
     net_cfg.pac_direct_fqdns = current_cfg.pac_direct_fqdns;
+    net_cfg.doh = requested_doh.unwrap_or(current_cfg.doh);
     if let Err(err) = &net_cfg.validate().await {
         log::error!("Invalid network settings: {}", err);
         return Ok(Box::new(get_error_response(err)));

--- a/web_frontend/src/blocking_enabled.rs
+++ b/web_frontend/src/blocking_enabled.rs
@@ -50,12 +50,8 @@ impl Component for BlockingEnabled {
                     match request.send().await {
                         Ok(response) => {
                             if response.ok() {
-                                message_callback.emit(Message::BlockingEnabled);
-
-                                return;
+                                message_callback.emit(Message::BlockingEnabled)
                             }
-
-                            message_callback.emit(Message::BlockingDisabled)
                         }
                         Err(_) => message_callback.emit(Message::BlockingDisabled),
                     }

--- a/web_frontend/src/debug.rs
+++ b/web_frontend/src/debug.rs
@@ -1,0 +1,170 @@
+use reqwasm::http::Request;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+use yew::{html, Component, Context, Html};
+
+/// Mirrors the backend `configuration::DebugConfig`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DebugConfig {
+    #[serde(default)]
+    pub scriptlet_console_logging: bool,
+}
+
+pub enum Message {
+    Loaded(DebugConfig),
+    ToggleScriptletLogging(bool),
+    SaveSucceeded(DebugConfig),
+    SaveFailed(String),
+}
+
+pub struct DebugSettingsPage {
+    config: DebugConfig,
+    loaded: bool,
+    saving: bool,
+    saved: bool,
+    error: Option<String>,
+}
+
+impl Component for DebugSettingsPage {
+    type Message = Message;
+    type Properties = ();
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let link = ctx.link().clone();
+        spawn_local(async move {
+            match Request::get("/api/settings/debug").send().await {
+                Ok(response) if response.ok() => {
+                    if let Ok(config) = response.json::<DebugConfig>().await {
+                        link.send_message(Message::Loaded(config));
+                    }
+                }
+                _ => log::error!("Failed to load debug settings"),
+            }
+        });
+
+        Self {
+            config: DebugConfig::default(),
+            loaded: false,
+            saving: false,
+            saved: false,
+            error: None,
+        }
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Message::Loaded(config) => {
+                self.config = config;
+                self.loaded = true;
+                true
+            }
+            Message::ToggleScriptletLogging(value) => {
+                // Optimistically reflect the new value, then persist. The PUT
+                // triggers a backend reload, so it takes effect on newly served
+                // pages.
+                self.config.scriptlet_console_logging = value;
+                self.saving = true;
+                self.saved = false;
+                self.error = None;
+                let config = self.config.clone();
+                let link = ctx.link().clone();
+                spawn_local(async move {
+                    let body = serde_json::to_string(&config).unwrap();
+                    match Request::put("/api/settings/debug")
+                        .header("Content-Type", "application/json")
+                        .body(body)
+                        .send()
+                        .await
+                    {
+                        Ok(response) if response.ok() => {
+                            link.send_message(Message::SaveSucceeded(config));
+                        }
+                        Ok(response) => {
+                            link.send_message(Message::SaveFailed(format!(
+                                "Failed to save (HTTP {})",
+                                response.status()
+                            )));
+                        }
+                        Err(err) => link.send_message(Message::SaveFailed(format!("{err}"))),
+                    }
+                });
+                true
+            }
+            Message::SaveSucceeded(config) => {
+                self.config = config;
+                self.saving = false;
+                self.saved = true;
+                self.error = None;
+                true
+            }
+            Message::SaveFailed(message) => {
+                self.saving = false;
+                self.saved = false;
+                self.error = Some(message);
+                true
+            }
+        }
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        if !self.loaded {
+            return html! { <div>{"Loading..."}</div> };
+        }
+
+        let on_toggle = ctx.link().callback(|e: MouseEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            Message::ToggleScriptletLogging(input.checked())
+        });
+
+        let status = if self.saving {
+            html! { <span class="text-sm text-gray-400 ml-2">{"Saving..."}</span> }
+        } else if self.saved {
+            html! { <span class="text-sm text-green-600 ml-2">{"Saved"}</span> }
+        } else {
+            html! {}
+        };
+
+        html! {
+            <>
+                <div class="pt-1.5 mb-4">
+                    <h1 class="text-2xl font-bold text-gray-900">{ "Debug" }</h1>
+                </div>
+
+                <fieldset class="mb-8" style="width: 100%;">
+                    <legend class="text-lg font-medium text-gray-900">{ "Scriptlet diagnostics" }</legend>
+                    <div class="mt-4 border-t border-b border-gray-200 divide-y divide-gray-200">
+                        <div class="mb-4" style="display: flex; flex-direction: column; width: 100%; padding: 2px 0;">
+                            <div style="display: flex; align-items: center; width: 100%;">
+                                <div class="text-gray-500" style="width: 260px; text-align: left; padding-right: 4px;">
+                                    { "Log scriptlet errors to console" }
+                                </div>
+                                <div style="flex-grow: 1;">
+                                    <input
+                                        checked={self.config.scriptlet_console_logging}
+                                        onclick={on_toggle}
+                                        disabled={self.saving}
+                                        type="checkbox"
+                                        class="focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 rounded"
+                                    />
+                                    { status }
+                                </div>
+                            </div>
+                            <div style="margin-left: 260px;">
+                                <p class="text-gray-400 text-sm">
+                                    { "Surface errors thrown by injected uBO scriptlets in the page's developer console as " }
+                                    <span class="font-mono bg-gray-100 px-1">{ "[privaxy scriptlet]" }</span>
+                                    { " entries, instead of silently swallowing them. Noisy and reveals that Privaxy is intercepting the page \u{2014} leave off unless troubleshooting." }
+                                </p>
+                                if let Some(error) = &self.error {
+                                    <p class="text-red-500 text-xs italic">{ error.clone() }</p>
+                                }
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </>
+        }
+    }
+}

--- a/web_frontend/src/debug.rs
+++ b/web_frontend/src/debug.rs
@@ -1,20 +1,41 @@
+use crate::logs::LogStream;
 use reqwasm::http::Request;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen_futures::spawn_local;
-use web_sys::HtmlInputElement;
+use web_sys::{HtmlInputElement, HtmlSelectElement};
 use yew::prelude::*;
 use yew::{html, Component, Context, Html};
 
+/// Selectable log verbosities, matching the backend `logging::LogLevel`
+/// (serialized lowercase).
+const LOG_LEVELS: [&str; 6] = ["off", "error", "warn", "info", "debug", "trace"];
+
+fn default_log_level() -> String {
+    "info".to_string()
+}
+
 /// Mirrors the backend `configuration::DebugConfig`.
-#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DebugConfig {
     #[serde(default)]
     pub scriptlet_console_logging: bool,
+    #[serde(default = "default_log_level")]
+    pub log_level: String,
+}
+
+impl Default for DebugConfig {
+    fn default() -> Self {
+        Self {
+            scriptlet_console_logging: false,
+            log_level: default_log_level(),
+        }
+    }
 }
 
 pub enum Message {
     Loaded(DebugConfig),
     ToggleScriptletLogging(bool),
+    SetLogLevel(String),
     SaveSucceeded(DebugConfig),
     SaveFailed(String),
 }
@@ -65,31 +86,14 @@ impl Component for DebugSettingsPage {
                 // triggers a backend reload, so it takes effect on newly served
                 // pages.
                 self.config.scriptlet_console_logging = value;
-                self.saving = true;
-                self.saved = false;
-                self.error = None;
-                let config = self.config.clone();
-                let link = ctx.link().clone();
-                spawn_local(async move {
-                    let body = serde_json::to_string(&config).unwrap();
-                    match Request::put("/api/settings/debug")
-                        .header("Content-Type", "application/json")
-                        .body(body)
-                        .send()
-                        .await
-                    {
-                        Ok(response) if response.ok() => {
-                            link.send_message(Message::SaveSucceeded(config));
-                        }
-                        Ok(response) => {
-                            link.send_message(Message::SaveFailed(format!(
-                                "Failed to save (HTTP {})",
-                                response.status()
-                            )));
-                        }
-                        Err(err) => link.send_message(Message::SaveFailed(format!("{err}"))),
-                    }
-                });
+                self.persist(ctx);
+                true
+            }
+            Message::SetLogLevel(level) => {
+                // The backend applies the level live (no reload needed) on the
+                // PUT; we persist it so it survives restarts.
+                self.config.log_level = level;
+                self.persist(ctx);
                 true
             }
             Message::SaveSucceeded(config) => {
@@ -126,6 +130,12 @@ impl Component for DebugSettingsPage {
             html! {}
         };
 
+        let on_level_change = ctx.link().callback(|e: Event| {
+            let select: HtmlSelectElement = e.target_unchecked_into();
+            Message::SetLogLevel(select.value())
+        });
+        let current_level = self.config.log_level.clone();
+
         html! {
             <>
                 <div class="pt-1.5 mb-4">
@@ -148,7 +158,7 @@ impl Component for DebugSettingsPage {
                                         type="checkbox"
                                         class="focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 rounded"
                                     />
-                                    { status }
+                                    { status.clone() }
                                 </div>
                             </div>
                             <div style="margin-left: 260px;">
@@ -164,7 +174,75 @@ impl Component for DebugSettingsPage {
                         </div>
                     </div>
                 </fieldset>
+
+                <fieldset class="mb-8" style="width: 100%;">
+                    <legend class="text-lg font-medium text-gray-900">{ "Logging" }</legend>
+                    <div class="mt-4 border-t border-b border-gray-200 divide-y divide-gray-200">
+                        <div class="mb-4" style="display: flex; flex-direction: column; width: 100%; padding: 2px 0;">
+                            <div style="display: flex; align-items: center; width: 100%;">
+                                <div class="text-gray-500" style="width: 260px; text-align: left; padding-right: 4px;">
+                                    { "Log level" }
+                                </div>
+                                <div style="flex-grow: 1;">
+                                    <select
+                                        onchange={on_level_change}
+                                        disabled={self.saving}
+                                        class="block pl-3 pr-8 py-1.5 text-sm border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+                                        { for LOG_LEVELS.iter().map(|level| html! {
+                                            <option value={*level} selected={current_level == *level}>
+                                                { level.to_uppercase() }
+                                            </option>
+                                        }) }
+                                    </select>
+                                    { status }
+                                </div>
+                            </div>
+                            <div style="margin-left: 260px;">
+                                <p class="text-gray-400 text-sm">
+                                    { "Verbosity of Privaxy's own logs, applied immediately and persisted. Dependency logs stay governed by the " }
+                                    <span class="font-mono bg-gray-100 px-1">{ "RUST_LOG" }</span>
+                                    { " environment variable." }
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+
+                <LogStream />
             </>
         }
+    }
+}
+
+impl DebugSettingsPage {
+    /// Persists the current config to the backend, reflecting save state via
+    /// `SaveSucceeded`/`SaveFailed` messages.
+    fn persist(&mut self, ctx: &Context<Self>) {
+        self.saving = true;
+        self.saved = false;
+        self.error = None;
+
+        let config = self.config.clone();
+        let link = ctx.link().clone();
+        spawn_local(async move {
+            let body = serde_json::to_string(&config).unwrap();
+            match Request::put("/api/settings/debug")
+                .header("Content-Type", "application/json")
+                .body(body)
+                .send()
+                .await
+            {
+                Ok(response) if response.ok() => {
+                    link.send_message(Message::SaveSucceeded(config));
+                }
+                Ok(response) => {
+                    link.send_message(Message::SaveFailed(format!(
+                        "Failed to save (HTTP {})",
+                        response.status()
+                    )));
+                }
+                Err(err) => link.send_message(Message::SaveFailed(format!("{err}"))),
+            }
+        });
     }
 }

--- a/web_frontend/src/filterlists.rs
+++ b/web_frontend/src/filterlists.rs
@@ -2,7 +2,7 @@ use crate::button;
 use crate::button::{ButtonColor, ButtonState, PrivaxyButton};
 use crate::filters::{AddFilterRequest, Filter, FilterConfiguration, FilterGroup};
 use crate::save_button::BASE_BUTTON_CSS;
-use crate::{save_button, submit_banner};
+use crate::{failure_banner, save_button, submit_banner, ApiError};
 use filterlists_api;
 use reqwasm::http::Request;
 use url::Url;
@@ -19,6 +19,8 @@ pub enum SearchFilterMessage {
     RemoveFilter(filterlists_api::Filter),
     LoadFilters,
     FiltersLoaded(Vec<filterlists_api::Filter>),
+    AddFilterFailed(String, String),
+    AcknowledgeError,
     Error(String),
     NextPage,
     PreviousPage,
@@ -39,6 +41,7 @@ pub struct SearchFilterList {
     current_page: usize,
     results_per_page: usize,
     active_filters: FilterConfiguration,
+    error_message: Option<String>,
 }
 
 const FILTER_TAG_GROUPS: [&'static str; 4] = ["ads", "privacy", "malware", "social"];
@@ -65,6 +68,7 @@ impl Component for SearchFilterList {
             current_page: 1,
             results_per_page: 10,
             active_filters: _ctx.props().filter_configuration.clone(),
+            error_message: None,
         }
     }
 
@@ -95,32 +99,49 @@ impl Component for SearchFilterList {
                     .next()
                     .unwrap_or(FilterGroup::Regional);
 
+                self.error_message = None;
                 self.active_filters.push(Filter::new(
                     filter.name.clone(),
                     FilterGroup::Malware,
                     "".to_string(),
                 ));
                 let filter_name = filter.name.clone();
+                let rollback_name = filter.name.clone();
                 let filter_id = filter.id;
+                let link = self.link.clone();
                 spawn_local(async move {
                     let parsed_url = match resolve_primary_view_url(filter_id).await {
                         Some(url) => url,
-                        None => return,
+                        None => {
+                            link.send_message(SearchFilterMessage::AddFilterFailed(
+                                rollback_name,
+                                "Could not resolve a download URL for this filter list".to_string(),
+                            ));
+                            return;
+                        }
                     };
                     let request_body = AddFilterRequest::new(filter_name, group, parsed_url);
                     let request = Request::post("/api/filters")
                         .header("Content-Type", "application/json")
                         .body(serde_json::to_string(&request_body).unwrap());
                     match request.send().await {
+                        Ok(response) if response.ok() => {
+                            log::info!("Filter added successfully");
+                        }
                         Ok(response) => {
-                            if response.ok() {
-                                log::info!("Filter added successfully");
-                            } else {
-                                log::error!("Failed to add filter: {:?}", response.status());
-                            }
+                            let err = response.json::<ApiError>().await.unwrap_or(ApiError {
+                                error: format!("HTTP {}", response.status()),
+                            });
+                            link.send_message(SearchFilterMessage::AddFilterFailed(
+                                rollback_name,
+                                err.error,
+                            ));
                         }
                         Err(err) => {
-                            log::error!("Request error: {:?}", err);
+                            link.send_message(SearchFilterMessage::AddFilterFailed(
+                                rollback_name,
+                                format!("{err:?}"),
+                            ));
                         }
                     }
                 })
@@ -267,6 +288,12 @@ impl Component for SearchFilterList {
                 log::info!("Tags loaded successfully");
                 self.tags = tags.clone();
             }
+            SearchFilterMessage::AddFilterFailed(name, error) => {
+                log::error!("Failed to add filter {name}: {error}");
+                self.active_filters.retain(|f| f.title != name);
+                self.error_message = Some(error);
+            }
+            SearchFilterMessage::AcknowledgeError => self.error_message = None,
             SearchFilterMessage::Error(error) => {
                 log::error!("Error loading filters: {}", error.to_string());
                 self.loading = false;
@@ -357,6 +384,16 @@ impl Component for SearchFilterList {
         let total_count = self.filters.len();
         let match_count = filtered_filters_len(&self.filters, &self.filter_query);
 
+        let failure_banner = match &self.error_message {
+            Some(message) => failure_banner!(
+                true,
+                self.link
+                    .callback(|_| SearchFilterMessage::AcknowledgeError),
+                message.clone()
+            ),
+            None => html! {},
+        };
+
         let modal_overlay = html! {
                         <div
                             class="fixed inset-0 bg-gray-600 bg-opacity-75 flex items-center justify-center z-50"
@@ -383,6 +420,7 @@ impl Component for SearchFilterList {
                                     </button>
                                 </div>
                                 <div class="flex flex-col flex-grow px-6 py-4 space-y-3 overflow-hidden">
+                                    { failure_banner }
                                     <input type="text" placeholder="Search by name" class="border border-gray-300 p-2 rounded focus:outline-none focus:ring-2 focus:ring-blue-300"
                                         value={self.filter_query.clone()}
                                         oninput={_ctx.link().callback(|e: InputEvent| {

--- a/web_frontend/src/filters.rs
+++ b/web_frontend/src/filters.rs
@@ -1,6 +1,6 @@
 use crate::button::ButtonState;
 use crate::filterlists::SearchFilterList;
-use crate::{save_button, submit_banner};
+use crate::{failure_banner, save_button, submit_banner, ApiError};
 use reqwasm::http::Request;
 use serde::{Deserialize, Serialize};
 use serde_json::de::IoRead;
@@ -58,6 +58,9 @@ pub enum AddFilterMessage {
     Open,
     Close,
     Save(String, String, FilterGroup),
+    Saved,
+    Failed(ApiError),
+    AcknowledgeError,
     CategoryChanged(FilterGroup),
     UrlChanged(String),
     TitleChanged(String),
@@ -91,6 +94,8 @@ pub struct AddFilterComponent {
     title: String,
     url: String,
     changes_saved: bool,
+    show_error: bool,
+    err_msg: String,
 }
 
 impl Component for AddFilterComponent {
@@ -105,6 +110,8 @@ impl Component for AddFilterComponent {
             url: String::new(),
             title: String::new(),
             changes_saved: false,
+            show_error: false,
+            err_msg: String::new(),
         }
     }
 
@@ -113,42 +120,64 @@ impl Component for AddFilterComponent {
             AddFilterMessage::Open => self.is_open = true,
             AddFilterMessage::Close => self.is_open = false,
             AddFilterMessage::Save(url, title, category) => {
-                if let Ok(parsed_url) = Url::parse(&url) {
-                    let request_body = AddFilterRequest {
-                        enabled: true,
-                        title: if title.is_empty() {
-                            self.url.clone()
-                        } else {
-                            title
-                        },
-                        group: category,
-                        url: parsed_url,
-                    };
+                let parsed_url = match Url::parse(&url) {
+                    Ok(parsed_url) => parsed_url,
+                    Err(err) => {
+                        self.link.send_message(AddFilterMessage::Failed(ApiError {
+                            error: format!("Invalid URL: {err}"),
+                        }));
+                        return true;
+                    }
+                };
 
-                    let request = Request::post("/api/filters")
-                        .header("Content-Type", "application/json")
-                        .body(serde_json::to_string(&request_body).unwrap());
+                let request_body = AddFilterRequest {
+                    enabled: true,
+                    title: if title.is_empty() {
+                        self.url.clone()
+                    } else {
+                        title
+                    },
+                    group: category,
+                    url: parsed_url,
+                };
 
-                    spawn_local(async move {
-                        match request.send().await {
-                            Ok(response) => {
-                                if response.ok() {
-                                    log::info!("Filter added successfully");
-                                } else {
-                                    log::error!("Failed to add filter: {:?}", response.status());
-                                }
-                            }
-                            Err(err) => {
-                                log::error!("Request error: {:?}", err);
-                            }
+                let request = Request::post("/api/filters")
+                    .header("Content-Type", "application/json")
+                    .body(serde_json::to_string(&request_body).unwrap());
+
+                let link = self.link.clone();
+                spawn_local(async move {
+                    match request.send().await {
+                        Ok(response) if response.ok() => {
+                            link.send_message(AddFilterMessage::Saved);
                         }
-                    });
-                } else {
-                    log::error!("Invalid URL: {}", url);
-                }
+                        Ok(response) => {
+                            let err = response.json::<ApiError>().await.unwrap_or(ApiError {
+                                error: format!("HTTP {}", response.status()),
+                            });
+                            link.send_message(AddFilterMessage::Failed(err));
+                        }
+                        Err(err) => {
+                            link.send_message(AddFilterMessage::Failed(ApiError {
+                                error: format!("{err:?}"),
+                            }));
+                        }
+                    }
+                });
+            }
+            AddFilterMessage::Saved => {
+                log::info!("Filter added successfully");
                 self.is_open = false;
+                self.show_error = false;
+                self.err_msg = String::new();
                 self.changes_saved = true;
             }
+            AddFilterMessage::Failed(err) => {
+                log::error!("Failed to add filter: {}", err.error);
+                self.show_error = true;
+                self.err_msg = err.error;
+            }
+            AddFilterMessage::AcknowledgeError => self.show_error = false,
             AddFilterMessage::CategoryChanged(category) => self.category = category,
             AddFilterMessage::UrlChanged(url) => self.url = url,
             AddFilterMessage::TitleChanged(title) => {
@@ -212,6 +241,16 @@ impl Component for AddFilterComponent {
         let category = self.category.clone();
         let title = self.title.clone();
 
+        let failure_banner = if self.show_error {
+            failure_banner!(
+                true,
+                _ctx.link().callback(|_| AddFilterMessage::AcknowledgeError),
+                self.err_msg.clone()
+            )
+        } else {
+            html! {}
+        };
+
         // <button onclick={self.link.callback(|_| AddFilterMessage::Open)} type="button" class="mt-5 button-base button-green">
         html! {
             <>
@@ -226,6 +265,7 @@ impl Component for AddFilterComponent {
                         <div class="fixed inset-0 bg-gray-600 bg-opacity-75 flex items-center justify-center z-50 ">
                             <div class="bg-white p-6 rounded-lg shadow-lg z-60">
                                 <div class="flex flex-col space-y-4">
+                                    { failure_banner }
                                     <div class="flex items-center">
                                         <div class="w-32">
                                             <label class="font-bold">{"Category"}</label>

--- a/web_frontend/src/general.rs
+++ b/web_frontend/src/general.rs
@@ -36,6 +36,9 @@ pub enum Message {
     ValidationSucceeded,
     CaSaveSuccess,
     UpdateTls(bool),
+    UpdateDohMode(String),
+    UpdateDohUpstream(String),
+    UpdateDohHosts(String),
     SaveSuccess,
     SaveFailed(ApiError),
     AcknowledgeError,
@@ -57,6 +60,50 @@ pub struct NetworkConfig {
     pub web_port: u16,
     /// Enable TLS for the web server.
     pub tls: bool,
+    /// DNS-over-HTTPS interception policy.
+    #[serde(default)]
+    pub doh: DohConfig,
+}
+
+/// How DNS-over-HTTPS requests passing through the proxy are handled. Mirrors
+/// the backend `configuration::DohMode`.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DohMode {
+    Off,
+    #[default]
+    Block,
+    Redirect,
+}
+
+impl DohMode {
+    fn as_value(&self) -> &'static str {
+        match self {
+            DohMode::Off => "off",
+            DohMode::Block => "block",
+            DohMode::Redirect => "redirect",
+        }
+    }
+
+    fn from_value(value: &str) -> Self {
+        match value {
+            "off" => DohMode::Off,
+            "redirect" => DohMode::Redirect,
+            _ => DohMode::Block,
+        }
+    }
+}
+
+/// DNS-over-HTTPS interception configuration. Mirrors the backend
+/// `configuration::DohConfig`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DohConfig {
+    #[serde(default)]
+    pub mode: DohMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_hosts: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -116,16 +163,30 @@ struct NetworkSettings {
     raw_proxy_port: String,
     raw_bind_addr: String,
     raw_web_port: String,
+    raw_doh_upstream: String,
+    raw_doh_hosts: String,
     proxy_port_error: Option<String>,
     bind_addr_error: Option<String>,
     web_port_error: Option<String>,
 }
 
 impl NetworkSettings {
+    /// Redirect mode is meaningless without an upstream resolver to forward to.
+    fn doh_upstream_error(&self) -> Option<String> {
+        let doh = &self.current_config.doh;
+        if doh.mode == DohMode::Redirect && doh.upstream.as_deref().unwrap_or("").trim().is_empty()
+        {
+            Some("An upstream resolver URL is required in redirect mode".to_string())
+        } else {
+            None
+        }
+    }
+
     fn validate(&self) -> bool {
         self.proxy_port_error.is_none()
             && self.bind_addr_error.is_none()
             && self.web_port_error.is_none()
+            && self.doh_upstream_error().is_none()
     }
     fn config_has_changed(&self) -> bool {
         self.current_config.clone() != self.remote_config
@@ -323,6 +384,8 @@ impl Component for GeneralSettings {
                         raw_proxy_port: network_config.proxy_port.to_string(),
                         raw_bind_addr: network_config.bind_addr.clone(),
                         raw_web_port: network_config.web_port.to_string(),
+                        raw_doh_upstream: network_config.doh.upstream.clone().unwrap_or_default(),
+                        raw_doh_hosts: network_config.doh.extra_hosts.join(", "),
                         proxy_port_error: None,
                         bind_addr_error: None,
                         web_port_error: None,
@@ -369,6 +432,32 @@ impl Component for GeneralSettings {
             Message::UpdateTls(value) => {
                 if let Some(ref mut network_settings) = self.network_settings {
                     network_settings.current_config.tls = value;
+                }
+            }
+            Message::UpdateDohMode(value) => {
+                if let Some(ref mut network_settings) = self.network_settings {
+                    network_settings.current_config.doh.mode = DohMode::from_value(&value);
+                }
+            }
+            Message::UpdateDohUpstream(value) => {
+                if let Some(ref mut network_settings) = self.network_settings {
+                    network_settings.raw_doh_upstream = value.clone();
+                    let trimmed = value.trim();
+                    network_settings.current_config.doh.upstream = if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_string())
+                    };
+                }
+            }
+            Message::UpdateDohHosts(value) => {
+                if let Some(ref mut network_settings) = self.network_settings {
+                    network_settings.raw_doh_hosts = value.clone();
+                    network_settings.current_config.doh.extra_hosts = value
+                        .split(',')
+                        .map(|host| host.trim().to_string())
+                        .filter(|host| !host.is_empty())
+                        .collect();
                 }
             }
             Message::UpdateCaCert(value) => {
@@ -543,6 +632,44 @@ impl Component for GeneralSettings {
                                             Message::UpdateTls(input.checked())
                                         }),
                                         "If the web server uses HTTPS") }
+                                    { render_select_setting(
+                                        "DoH handling",
+                                        network_settings.current_config.doh.mode.as_value(),
+                                        &[
+                                            ("off", "Off — leave DoH untouched"),
+                                            ("block", "Block — refuse DoH (clients fall back to system DNS)"),
+                                            ("redirect", "Redirect — forward to an upstream resolver"),
+                                        ],
+                                        ctx.link().callback(|e: Event| {
+                                            let input: web_sys::HtmlSelectElement = e.target_unchecked_into();
+                                            Message::UpdateDohMode(input.value())
+                                        }),
+                                        "How DNS-over-HTTPS requests passing through the proxy are handled."
+                                    ) }
+                                    if network_settings.current_config.doh.mode == DohMode::Redirect {
+                                        { render_setting(
+                                            "Upstream resolver",
+                                            network_settings.raw_doh_upstream.clone(),
+                                            ctx.link().callback(|e: InputEvent| {
+                                                let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                                Message::UpdateDohUpstream(input.value())
+                                            }),
+                                            network_settings.doh_upstream_error().as_ref(),
+                                            "DoH endpoint queries are forwarded to, e.g. https://dns.quad9.net/dns-query"
+                                        ) }
+                                    }
+                                    if network_settings.current_config.doh.mode != DohMode::Off {
+                                        { render_setting(
+                                            "Extra DoH hosts",
+                                            network_settings.raw_doh_hosts.clone(),
+                                            ctx.link().callback(|e: InputEvent| {
+                                                let input: web_sys::HtmlInputElement = e.target_unchecked_into();
+                                                Message::UpdateDohHosts(input.value())
+                                            }),
+                                            None,
+                                            "Comma-separated resolver hostnames to also treat as DoH, on top of the built-in list."
+                                        ) }
+                                    }
                                     </>
                                 }
                             }
@@ -664,6 +791,32 @@ fn render_certificate_setting(
                 if let Some(error_msg) = error {
                     <p class="text-red-500 text-xs italic">{error_msg}</p>
                 }
+            </div>
+        </div>
+    }
+}
+
+fn render_select_setting(
+    setting_name: &str,
+    selected: &str,
+    options: &[(&str, &str)],
+    onchange: Callback<Event>,
+    description: &str,
+) -> Html {
+    html! {
+        <div class="mb-4" style="display: flex; flex-direction: column; width: 100%; padding: 2px 0;">
+            <div style="display: flex; align-items: center; width: 100%;">
+                <div class="text-gray-500" style="width: 200px; text-align: left; padding-right: 4px;">{ setting_name }</div>
+                <div style="flex-grow: 1;">
+                    <select onchange={onchange} class="shadow appearance-none border rounded w-80 py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                        { for options.iter().map(|(value, label)| html! {
+                            <option value={value.to_string()} selected={*value == selected}>{ *label }</option>
+                        }) }
+                    </select>
+                </div>
+            </div>
+            <div style="margin-left: 200px;">
+                <p class="text-gray-400 text-sm">{description}</p>
             </div>
         </div>
     }

--- a/web_frontend/src/logs.rs
+++ b/web_frontend/src/logs.rs
@@ -1,0 +1,255 @@
+use futures::future::{AbortHandle, Abortable};
+use futures::StreamExt;
+use reqwasm::websocket::futures::WebSocket;
+use serde::Deserialize;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlSelectElement;
+use yew::{html, Component, Context, Html, TargetCast};
+
+/// Upper bound on retained rows in the browser, mirroring the requests feed so
+/// a long-running session can't grow unbounded.
+const MAX_LOGS_SHOWN: usize = 1000;
+
+/// Mirrors the backend `logging::LogEntry`.
+#[derive(Deserialize, Clone, PartialEq)]
+pub struct LogEntry {
+    now: String,
+    level: String,
+    target: String,
+    message: String,
+}
+
+impl LogEntry {
+    /// Severity rank, lower is more severe. Unknown levels sort last so they
+    /// are only hidden by the most permissive ("All") filter.
+    fn severity(&self) -> u8 {
+        match self.level.as_str() {
+            "ERROR" => 0,
+            "WARN" => 1,
+            "INFO" => 2,
+            "DEBUG" => 3,
+            "TRACE" => 4,
+            _ => 5,
+        }
+    }
+}
+
+/// Minimum severity selected in the level dropdown.
+#[derive(Clone, Copy, PartialEq)]
+enum LevelFilter {
+    All,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl LevelFilter {
+    fn from_value(value: &str) -> Self {
+        match value {
+            "ERROR" => Self::Error,
+            "WARN" => Self::Warn,
+            "INFO" => Self::Info,
+            "DEBUG" => Self::Debug,
+            "TRACE" => Self::Trace,
+            _ => Self::All,
+        }
+    }
+
+    /// Highest severity rank still shown. `All` keeps everything, including
+    /// unknown levels.
+    fn max_rank(&self) -> u8 {
+        match self {
+            Self::All => u8::MAX,
+            Self::Error => 0,
+            Self::Warn => 1,
+            Self::Info => 2,
+            Self::Debug => 3,
+            Self::Trace => 4,
+        }
+    }
+}
+
+pub enum Message {
+    Received(LogEntry),
+    SetFilter(LevelFilter),
+    TogglePause,
+    Clear,
+}
+
+pub struct LogStream {
+    entries: Vec<LogEntry>,
+    filter: LevelFilter,
+    paused: bool,
+    ws_abort_handle: AbortHandle,
+}
+
+impl Component for LogStream {
+    type Message = Message;
+    type Properties = ();
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let message_callback = ctx.link().callback(Message::Received);
+
+        let ws = WebSocket::open("/api/logs").unwrap();
+        let (_write, mut read) = ws.split();
+
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        let future = Abortable::new(
+            async move {
+                while let Some(Ok(msg)) = read.next().await {
+                    let entry = match msg {
+                        reqwasm::websocket::Message::Text(s) => {
+                            serde_json::from_str::<LogEntry>(&s).unwrap()
+                        }
+                        reqwasm::websocket::Message::Bytes(_) => unreachable!(),
+                    };
+
+                    message_callback.emit(entry);
+                }
+            },
+            abort_registration,
+        );
+
+        spawn_local(async {
+            let _result = future.await;
+        });
+
+        Self {
+            entries: Vec::new(),
+            filter: LevelFilter::All,
+            paused: false,
+            ws_abort_handle: abort_handle,
+        }
+    }
+
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Message::Received(entry) => {
+                // While paused the live view is frozen; incoming records are
+                // dropped rather than buffered.
+                if self.paused {
+                    return false;
+                }
+
+                self.entries.insert(0, entry);
+                self.entries.truncate(MAX_LOGS_SHOWN);
+                true
+            }
+            Message::SetFilter(filter) => {
+                self.filter = filter;
+                true
+            }
+            Message::TogglePause => {
+                self.paused = !self.paused;
+                true
+            }
+            Message::Clear => {
+                self.entries.clear();
+                true
+            }
+        }
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let link = ctx.link();
+
+        let on_filter_change = link.callback(|e: yew::events::Event| {
+            let select: HtmlSelectElement = e.target_unchecked_into();
+            Message::SetFilter(LevelFilter::from_value(&select.value()))
+        });
+        let on_toggle_pause = link.callback(|_| Message::TogglePause);
+        let on_clear = link.callback(|_| Message::Clear);
+
+        let max_rank = self.filter.max_rank();
+        let visible = self
+            .entries
+            .iter()
+            .filter(|entry| entry.severity() <= max_rank);
+
+        let pause_label = if self.paused { "Resume" } else { "Pause" };
+        let pause_classes = if self.paused {
+            "inline-flex items-center px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700"
+        } else {
+            "inline-flex items-center px-3 py-1.5 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+        };
+
+        html! {
+            <fieldset class="mb-8" style="width: 100%;">
+                <legend class="text-lg font-medium text-gray-900">
+                    { "Live logs" }
+                    if !self.paused {
+                        <div class="mt-2 ml-3 inline pulsating-circle"></div>
+                    }
+                </legend>
+                <p class="text-gray-400 text-sm mt-1 mb-3">
+                    { "Streams the server's log output (controlled by " }
+                    <span class="font-mono bg-gray-100 px-1">{ "RUST_LOG" }</span>
+                    { "). Filtering and pausing are local to this view and don't affect what the server records." }
+                </p>
+
+                <div class="flex items-center space-x-3 mb-3">
+                    <label class="text-sm text-gray-500">{ "Minimum level" }</label>
+                    <select
+                        onchange={on_filter_change}
+                        class="block pl-3 pr-8 py-1.5 text-sm border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+                        <option value="ALL" selected={self.filter == LevelFilter::All}>{ "All" }</option>
+                        <option value="ERROR" selected={self.filter == LevelFilter::Error}>{ "Error" }</option>
+                        <option value="WARN" selected={self.filter == LevelFilter::Warn}>{ "Warn" }</option>
+                        <option value="INFO" selected={self.filter == LevelFilter::Info}>{ "Info" }</option>
+                        <option value="DEBUG" selected={self.filter == LevelFilter::Debug}>{ "Debug" }</option>
+                        <option value="TRACE" selected={self.filter == LevelFilter::Trace}>{ "Trace" }</option>
+                    </select>
+                    <button type="button" onclick={on_toggle_pause} class={pause_classes}>
+                        { pause_label }
+                    </button>
+                    <button
+                        type="button"
+                        onclick={on_clear}
+                        class="inline-flex items-center px-3 py-1.5 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+                        { "Clear" }
+                    </button>
+                </div>
+
+                <div class="bg-gray-900 rounded-md overflow-x-auto" style="max-height: 32rem; overflow-y: auto;">
+                    <table class="min-w-full text-xs font-mono">
+                        <tbody>
+                            { for visible.map(Self::render_row) }
+                        </tbody>
+                    </table>
+                </div>
+            </fieldset>
+        }
+    }
+
+    fn destroy(&mut self, _ctx: &Context<Self>) {
+        self.ws_abort_handle.abort()
+    }
+}
+
+impl LogStream {
+    fn render_row(entry: &LogEntry) -> Html {
+        let level_classes = match entry.level.as_str() {
+            "ERROR" => "text-red-400",
+            "WARN" => "text-yellow-400",
+            "INFO" => "text-green-400",
+            "DEBUG" => "text-blue-400",
+            "TRACE" => "text-gray-400",
+            _ => "text-gray-300",
+        };
+
+        html! {
+            <tr class="border-b border-gray-800 align-top">
+                <td class="px-3 py-1 whitespace-nowrap text-gray-500">{ &entry.now }</td>
+                <td class={classes_for_level(level_classes)}>{ &entry.level }</td>
+                <td class="px-3 py-1 whitespace-nowrap text-gray-400">{ &entry.target }</td>
+                <td class="px-3 py-1 text-gray-200" style="word-break: break-word;">{ &entry.message }</td>
+            </tr>
+        }
+    }
+}
+
+fn classes_for_level(level_classes: &str) -> String {
+    format!("px-3 py-1 whitespace-nowrap font-semibold {level_classes}")
+}

--- a/web_frontend/src/main.rs
+++ b/web_frontend/src/main.rs
@@ -10,6 +10,7 @@ mod auth;
 mod blocking_enabled;
 mod button;
 mod dashboard;
+mod debug;
 mod filterlists;
 mod filters;
 mod general;

--- a/web_frontend/src/main.rs
+++ b/web_frontend/src/main.rs
@@ -14,6 +14,7 @@ mod debug;
 mod filterlists;
 mod filters;
 mod general;
+mod logs;
 mod pac;
 mod requests;
 mod save_button;

--- a/web_frontend/src/settings.rs
+++ b/web_frontend/src/settings.rs
@@ -1,4 +1,5 @@
 use crate::account::AccountSettings;
+use crate::debug::DebugSettingsPage;
 use crate::filters::Filters;
 use crate::general::GeneralSettings;
 use crate::pac::PacSettingsPage;
@@ -22,6 +23,8 @@ pub enum SettingsRoute {
     Pac,
     #[at("/settings/account")]
     Account,
+    #[at("/settings/debug")]
+    Debug,
 }
 
 pub fn switch_settings(route: &SettingsRoute) -> Html {
@@ -111,6 +114,11 @@ pub fn switch_settings(route: &SettingsRoute) -> Html {
 
             html! { <AccountSettings /> }
         }
+        SettingsRoute::Debug => {
+            set_title("Settings - Debug");
+
+            html! { <DebugSettingsPage /> }
+        }
     };
 
     html! {<div class="md:grid md:grid-cols-8">
@@ -121,6 +129,7 @@ pub fn switch_settings(route: &SettingsRoute) -> Html {
         <Link<SettingsRoute> classes={get_classes(*route, SettingsRoute::CustomFilters)} to={SettingsRoute::CustomFilters}> <span class="truncate">{ "Custom filters" }</span></Link<SettingsRoute>>
         <Link<SettingsRoute> classes={get_classes(*route, SettingsRoute::Pac)} to={SettingsRoute::Pac}> <span class="truncate">{ "PAC" }</span></Link<SettingsRoute>>
         <Link<SettingsRoute> classes={get_classes(*route, SettingsRoute::Account)} to={SettingsRoute::Account}> <span class="truncate">{ "Account" }</span></Link<SettingsRoute>>
+        <Link<SettingsRoute> classes={get_classes(*route, SettingsRoute::Debug)} to={SettingsRoute::Debug}> <span class="truncate">{ "Debug" }</span></Link<SettingsRoute>>
     </nav>
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 mt-4 sm:col-span-6">{ content }</div>
     </div>


### PR DESCRIPTION
- Fix WebSocket / protocol-upgrade connections hanging
  - Upgrade requests (`wss://`, and proprietary HTTP-upgrade transports like MMTLS long-link) could spin forever with `upgrade expected but not completed`. The proxy fabricated a `101 Switching Protocols` to the client regardless of what the upstream actually returned, so a failed upgrade left the client waiting on a tunnel that was never bridged. It now forwards the upstream's real response when it isn't a genuine `101`, and the dedicated upgrade HTTP client gained the same connection hardening (`connect_timeout`, `tcp_keepalive`, no idle pooling) as the main client.
  - Excluded hosts performing a plain-HTTP protocol upgrade are now blind-tunneled at the TCP level instead of being run through the (HTTP-only) upgrade bridge, so MITM-excluded apps using non-HTTP upgrade protocols work. Previously the exclusion list was only consulted on the `CONNECT` path, so excluding such a host had no effect on its plain-HTTP upgrade traffic.
  - When an opaque (non-WebSocket) upgrade is seen for a host that is *not* excluded, a warning is logged naming the host and suggesting it be added to the exclusions, instead of failing cryptically.
- Validate filter lists when added
  - Adding a filter now rejects URLs that do not serve a `text/plain` filter list (e.g. an HTML error/landing page returned with a `200`) with a `422`, instead of silently saving a broken filter. The error is surfaced in the web UI, and filters whose URL stops serving a list are dropped from the engine with a warning on the next refresh.
- Fix proxied requests randomly hanging/timing out
  - The outbound HTTP client had no connection timeouts, so a pooled keep-alive connection silently dropped by the remote would be reused and block until the OS TCP timeout (minutes). Added `connect_timeout`, `pool_idle_timeout`, and `tcp_keepalive`.
- DNS-over-HTTPS (DoH) interception
  - Detects DoH requests passing through the MITM proxy (RFC 8484 `application/dns-message`, JSON DoH, and known resolver endpoints)
  - `block` mode (default) refuses DoH so fallback-mode clients (e.g. default Firefox) revert to the system resolver, which Privaxy already sees — the HTTP-layer equivalent of the `use-application-dns.net` canary a non-DNS proxy cannot serve
  - `redirect` mode transparently forwards queries to a configured `upstream` resolver
  - Configured under `[network.doh]` (`mode`, `upstream`, `extra_hosts`) or from the web UI under Settings → General; MITM-excluded hosts are left untouched
- Fix cookie not invalidating upon logout/cred change
- All four engine-matching call sites now use match_url (canonical, default port stripped); the outbound request and stats still use the raw uri with its port, so nothing about proxying changes. This was silently breaking every hostname-anchored (||host/path) network rule on every HTTPS site
- Update ublock annoyances url
- Add support for MIPS, MIPSLE
- Injected uBlock scriptlets now actually run
  - Even after the 0.7.0 scriptlet repair, every injected `##+js(...)` scriptlet was a silent no-op. adblock-rust emits scriptlet bodies that reference an ambient `scriptletGlobals` object (uBlock Origin supplies it in its own injector; adblock-rust leaves it to the embedder), so the first internal call threw `ReferenceError: scriptletGlobals is not defined`, which each scriptlet's own `try/catch` swallowed. Privaxy now defines `scriptletGlobals` at the top of the injected payload, so `abort-current-script`, `prevent-addEventListener`, `abort-on-property-read`, `set-cookie`, etc. take effect.
- Procedural cosmetic filtering
  - Non-CSS procedural filters are no longer dropped (previously only filters reducible to plain CSS were applied). `:has-text`, `:matches-css`/`-before`/`-after`, `:matches-attr`, `:matches-path`, `:min-text-length`, `:upward`, `:xpath`, and the `:remove()`/`:style()`/`remove-attr`/`remove-class` actions are now evaluated in-page by an injected shim.
  - The shim re-runs on DOM mutations and recurses into same-origin child frames (`about:blank`/`srcdoc`/`data:` with `allow-same-origin`), so ad content written into such frames after load is also matched. Cross-origin frames and closed shadow DOM remain out of reach.
- Scriptlet error logging (debugging)
  - New opt-in `debug.scriptlet_console_logging` (off by default), toggleable from Settings → Debug, surfaces errors thrown by injected scriptlets in the page console as `[privaxy scriptlet]` entries instead of swallowing them.
- Live log streaming in the web UI
  - Settings → Debug now shows the server's log output in real time
  - The level can be changed in the webui
- Fix cosmetic "modified responses" statistic undercount
  - Pages where only element-hiding (`display: none`) selectors were injected were not counted as modified; any injected cosmetic CSS now counts
