### PR TITLE
feature/fix: css scriptlet, fix js scriptlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.7.0-0.7.1
+## v0.7.1
 
 - Validate filter lists when added
   - Adding a filter now rejects URLs that do not serve a `text/plain` filter list (e.g. an HTML error/landing page returned with a `200`) with a `422`, instead of silently saving a broken filter. The error is surfaced in the web UI, and filters whose URL stops serving a list are dropped from the engine with a warning on the next refresh.
@@ -15,6 +15,18 @@
 - All four engine-matching call sites now use match_url (canonical, default port stripped); the outbound request and stats still use the raw uri with its port, so nothing about proxying changes. This was silently breaking every hostname-anchored (||host/path) network rule on every HTTPS site
 - Update ublock annoyances url
 - Add support for MIPS, MIPSLE
+- Injected uBlock scriptlets now actually run
+  - Even after the 0.7.0 scriptlet repair, every injected `##+js(...)` scriptlet was a silent no-op. adblock-rust emits scriptlet bodies that reference an ambient `scriptletGlobals` object (uBlock Origin supplies it in its own injector; adblock-rust leaves it to the embedder), so the first internal call threw `ReferenceError: scriptletGlobals is not defined`, which each scriptlet's own `try/catch` swallowed. Privaxy now defines `scriptletGlobals` at the top of the injected payload, so `abort-current-script`, `prevent-addEventListener`, `abort-on-property-read`, `set-cookie`, etc. take effect.
+- Procedural cosmetic filtering
+  - Non-CSS procedural filters are no longer dropped (previously only filters reducible to plain CSS were applied). `:has-text`, `:matches-css`/`-before`/`-after`, `:matches-attr`, `:matches-path`, `:min-text-length`, `:upward`, `:xpath`, and the `:remove()`/`:style()`/`remove-attr`/`remove-class` actions are now evaluated in-page by an injected shim.
+  - The shim re-runs on DOM mutations and recurses into same-origin child frames (`about:blank`/`srcdoc`/`data:` with `allow-same-origin`), so ad content written into such frames after load is also matched. Cross-origin frames and closed shadow DOM remain out of reach.
+- Scriptlet error logging (debugging)
+  - New opt-in `debug.scriptlet_console_logging` (off by default), toggleable from Settings → Debug, surfaces errors thrown by injected scriptlets in the page console as `[privaxy scriptlet]` entries instead of swallowing them.
+- Fix cosmetic "modified responses" statistic undercount
+  - Pages where only element-hiding (`display: none`) selectors were injected were not counted as modified; any injected cosmetic CSS now counts
+
+## v0.7.0
+
 - Built-in authentication for the web UI and API
   - First-run setup page for choosing an admin username + password
   - 30-day HMAC-signed session cookie
@@ -31,6 +43,7 @@
 - Fix(?) memory leak
 - Inject into CSP-protected websites
 - Add docker compose example
+
 
 ## v0.6.0
 

--- a/privaxy/src/resources/procedural_cosmetics.js
+++ b/privaxy/src/resources/procedural_cosmetics.js
@@ -1,0 +1,328 @@
+/*
+ * Privaxy in-page procedural cosmetic filtering shim.
+ *
+ * The proxy can apply plain-CSS cosmetic rules server-side by injecting a
+ * <style> block, but uBO/AdGuard procedural rules (:has-text, :matches-css,
+ * :upward, :xpath, :remove(), …) need to be evaluated against the live DOM.
+ * This shim receives those rules as JSON and applies them on load and on every
+ * subsequent DOM mutation.
+ *
+ * Rules are evaluated against the top document AND every reachable child-frame
+ * document. Same-origin frames built without a network fetch (`about:blank`,
+ * `srcdoc`, `data:`) never reach the proxy, so the only way to filter their
+ * contents is from the parent page — which we can do whenever the frame is
+ * same-origin (e.g. a `sandbox` that includes `allow-same-origin`). Cross-origin
+ * frames throw on document access and are silently skipped (those are filtered
+ * via their own proxied response instead).
+ *
+ * Each rule is a ProceduralOrActionFilter:
+ *   { "selector": [ { "type": "css-selector", "arg": "…" }, … ],
+ *     "action":   { "type": "style"|"remove"|"remove-attr"|"remove-class",
+ *                   "arg": "…" } }      // action is optional => hide
+ *
+ * Defined as an idempotent global so repeated injection on a page is harmless.
+ */
+window.__privaxyApplyProcedural = window.__privaxyApplyProcedural || (function () {
+    "use strict";
+
+    var REGEX_LITERAL = /^\/(.*)\/([a-z]*)$/;
+
+    // Build a string predicate from a uBO argument.
+    //   mode "substring" — plain text is a substring test (:has-text, path)
+    //   mode "wildcard"  — plain text supports `*` wildcards, full match
+    // A `/pattern/flags` argument is always treated as a regular expression.
+    function makeMatcher(arg, mode) {
+        var m = REGEX_LITERAL.exec(arg);
+        if (m !== null) {
+            var re = new RegExp(m[1], m[2]);
+            return function (value) {
+                return re.test(value);
+            };
+        }
+        if (mode === "wildcard") {
+            var escaped = arg.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+            var wild = new RegExp("^" + escaped + "$");
+            return function (value) {
+                return wild.test(value);
+            };
+        }
+        return function (value) {
+            return value.indexOf(arg) !== -1;
+        };
+    }
+
+    function uniqueElements(nodes) {
+        var seen = new Set();
+        var out = [];
+        for (var i = 0; i < nodes.length; i++) {
+            var node = nodes[i];
+            if (node && node.nodeType === 1 && !seen.has(node)) {
+                seen.add(node);
+                out.push(node);
+            }
+        }
+        return out;
+    }
+
+    function matchesCss(scope, node, arg, pseudo) {
+        var sep = arg.indexOf(":");
+        if (sep === -1) {
+            return false;
+        }
+        var prop = arg.slice(0, sep).trim();
+        var matcher = makeMatcher(arg.slice(sep + 1).trim(), "wildcard");
+        var style = scope.win.getComputedStyle(node, pseudo || null);
+        return matcher(style.getPropertyValue(prop).trim());
+    }
+
+    function matchesAttr(node, arg) {
+        var sep = arg.indexOf("=");
+        var nameArg = sep === -1 ? arg : arg.slice(0, sep);
+        var nameMatcher = makeMatcher(nameArg.trim(), "wildcard");
+        var valueMatcher = null;
+        if (sep !== -1) {
+            var rawValue = arg.slice(sep + 1).trim().replace(/^["']|["']$/g, "");
+            valueMatcher = makeMatcher(rawValue, "wildcard");
+        }
+        var attrs = node.attributes;
+        for (var i = 0; i < attrs.length; i++) {
+            if (nameMatcher(attrs[i].name)) {
+                if (valueMatcher === null || valueMatcher(attrs[i].value)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    function climbUpward(node, arg) {
+        var steps = parseInt(arg, 10);
+        if (String(steps) === arg.trim()) {
+            var current = node;
+            while (steps-- > 0 && current !== null) {
+                current = current.parentElement;
+            }
+            return current;
+        }
+        return node.parentElement !== null ? node.parentElement.closest(arg) : null;
+    }
+
+    function evaluateXpath(scope, contextNode, arg) {
+        var result = scope.doc.evaluate(
+            arg,
+            contextNode,
+            null,
+            XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+            null
+        );
+        var out = [];
+        for (var i = 0; i < result.snapshotLength; i++) {
+            out.push(result.snapshotItem(i));
+        }
+        return out;
+    }
+
+    // Apply one operator to the running node set within `scope` (a {doc, win}
+    // pair). `nodes` is null until the first selector seeds it from the document.
+    function applyOperator(scope, nodes, op) {
+        var arg = op.arg;
+        switch (op.type) {
+            case "css-selector":
+                if (nodes === null) {
+                    return Array.prototype.slice.call(scope.doc.querySelectorAll(arg));
+                }
+                return nodes.reduce(function (acc, node) {
+                    return acc.concat(Array.prototype.slice.call(node.querySelectorAll(arg)));
+                }, []);
+            case "has-text": {
+                var textMatcher = makeMatcher(arg, "substring");
+                return (nodes || []).filter(function (node) {
+                    return textMatcher(node.textContent || "");
+                });
+            }
+            case "min-text-length": {
+                var minLength = parseInt(arg, 10);
+                return (nodes || []).filter(function (node) {
+                    return (node.textContent || "").length >= minLength;
+                });
+            }
+            case "matches-path": {
+                var pathMatcher = makeMatcher(arg, "substring");
+                var path = scope.win.location.pathname + scope.win.location.search;
+                return pathMatcher(path) ? (nodes || []) : [];
+            }
+            case "matches-css":
+                return (nodes || []).filter(function (node) {
+                    return matchesCss(scope, node, arg, null);
+                });
+            case "matches-css-before":
+                return (nodes || []).filter(function (node) {
+                    return matchesCss(scope, node, arg, "::before");
+                });
+            case "matches-css-after":
+                return (nodes || []).filter(function (node) {
+                    return matchesCss(scope, node, arg, "::after");
+                });
+            case "matches-attr":
+                return (nodes || []).filter(function (node) {
+                    return matchesAttr(node, arg);
+                });
+            case "upward":
+                return uniqueElements((nodes || []).map(function (node) {
+                    return climbUpward(node, arg);
+                }));
+            case "xpath":
+                if (nodes === null) {
+                    return evaluateXpath(scope, scope.doc, arg);
+                }
+                return uniqueElements((nodes || []).reduce(function (acc, node) {
+                    return acc.concat(evaluateXpath(scope, node, arg));
+                }, []));
+            default:
+                return nodes || [];
+        }
+    }
+
+    function selectNodes(scope, selector) {
+        var nodes = null;
+        for (var i = 0; i < selector.length; i++) {
+            nodes = applyOperator(scope, nodes, selector[i]);
+            if (nodes !== null && nodes.length === 0) {
+                return [];
+            }
+        }
+        return uniqueElements(nodes || []);
+    }
+
+    function applyStyle(node, declarations) {
+        declarations.split(";").forEach(function (declaration) {
+            var sep = declaration.indexOf(":");
+            if (sep === -1) {
+                return;
+            }
+            var prop = declaration.slice(0, sep).trim();
+            var value = declaration.slice(sep + 1).trim();
+            var priority = "";
+            if (/!important$/.test(value)) {
+                value = value.replace(/!important$/, "").trim();
+                priority = "important";
+            }
+            if (prop !== "") {
+                node.style.setProperty(prop, value, priority);
+            }
+        });
+    }
+
+    function applyAction(node, action) {
+        if (!action) {
+            node.style.setProperty("display", "none", "important");
+            return;
+        }
+        switch (action.type) {
+            case "style":
+                applyStyle(node, action.arg);
+                break;
+            case "remove":
+                node.remove();
+                break;
+            case "remove-attr":
+                node.removeAttribute(action.arg);
+                break;
+            case "remove-class":
+                node.classList.remove(action.arg);
+                break;
+        }
+    }
+
+    return function (filters) {
+        if (!Array.isArray(filters) || filters.length === 0) {
+            return;
+        }
+
+        var scheduled = false;
+        var observedDocs = new WeakSet();
+
+        // Walk this window and every reachable same-origin descendant frame,
+        // returning a {doc, win} scope for each. Cross-origin frames throw on
+        // document access and are skipped.
+        function collectScopes() {
+            var scopes = [];
+            var seenDocs = new Set();
+            (function visit(win) {
+                var doc;
+                try {
+                    doc = win.document;
+                } catch (err) {
+                    return;
+                }
+                if (!doc || seenDocs.has(doc)) {
+                    return;
+                }
+                seenDocs.add(doc);
+                scopes.push({ doc: doc, win: win });
+                var frames = doc.querySelectorAll("iframe, frame");
+                for (var i = 0; i < frames.length; i++) {
+                    var childWin = null;
+                    try {
+                        childWin = frames[i].contentWindow;
+                    } catch (err) {
+                        childWin = null;
+                    }
+                    if (childWin) {
+                        visit(childWin);
+                    }
+                }
+            })(window);
+            return scopes;
+        }
+
+        // Ads are often written into a frame *after* it's created, and a
+        // parent's observer doesn't see mutations inside a child document, so
+        // each reachable frame document gets its own observer (once).
+        function ensureObserved(doc) {
+            if (observedDocs.has(doc)) {
+                return;
+            }
+            observedDocs.add(doc);
+            var observer = new MutationObserver(schedule);
+            observer.observe(doc.documentElement || doc, { childList: true, subtree: true });
+        }
+
+        function apply() {
+            scheduled = false;
+            var scopes = collectScopes();
+            for (var s = 0; s < scopes.length; s++) {
+                var scope = scopes[s];
+                ensureObserved(scope.doc);
+                for (var i = 0; i < filters.length; i++) {
+                    // A single malformed rule (or a frame torn down mid-pass)
+                    // must not break the rest; throwing is part of normal
+                    // operation here.
+                    try {
+                        var nodes = selectNodes(scope, filters[i].selector);
+                        for (var j = 0; j < nodes.length; j++) {
+                            applyAction(nodes[j], filters[i].action);
+                        }
+                    } catch (err) {
+                        /* ignore this rule and continue */
+                    }
+                }
+            }
+        }
+
+        // Observers only feed `childList` mutations, so our hide/style/attr
+        // edits don't loop; a `:remove()` converges in one extra debounced pass.
+        function schedule() {
+            if (scheduled) {
+                return;
+            }
+            scheduled = true;
+            window.requestAnimationFrame(apply);
+        }
+
+        schedule();
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", schedule);
+        }
+    };
+})();

--- a/privaxy/src/server/blocker.rs
+++ b/privaxy/src/server/blocker.rs
@@ -62,6 +62,11 @@ pub struct CosmeticBlockerResult {
     pub hidden_selectors: Vec<String>,
     pub style_selectors: HashMap<String, Vec<String>>,
     pub injected_script: Option<String>,
+    /// JSON-encoded `ProceduralOrActionFilter` records that cannot be reduced to
+    /// plain CSS (`:has-text`, `:matches-css`, `:upward`, `:xpath`, `:remove()`,
+    /// …). These are handed to the in-page procedural shim, which evaluates them
+    /// against the live DOM. Empty for the vast majority of hosts.
+    pub procedural_filters: Vec<String>,
 }
 
 pub struct BlockerRequest {
@@ -135,6 +140,7 @@ impl Blocker {
                                 hidden_selectors: Vec::new(),
                                 style_selectors: HashMap::new(),
                                 injected_script: None,
+                                procedural_filters: Vec::new(),
                             },
                         ));
                         continue;
@@ -165,20 +171,25 @@ impl Blocker {
 
                     // adblock 0.12 replaced UrlSpecificResources::style_selectors
                     // with `procedural_actions`, a HashSet of JSON-encoded
-                    // ProceduralOrActionFilter records. Re-derive the
-                    // (selector -> style) map from the ones that reduce to
-                    // pure CSS via `as_css()`; non-CSS procedural filters
-                    // (those needing in-page JS to apply) are dropped — the
-                    // proxy can't run JS-driven procedural matching.
+                    // ProceduralOrActionFilter records. Records that reduce to
+                    // pure CSS via `as_css()` are applied server-side as a
+                    // (selector -> style) map. The rest need in-page JS to
+                    // evaluate (`:has-text`, `:matches-css`, `:upward`, `:xpath`,
+                    // `:remove()`, …); their raw JSON is forwarded to the
+                    // procedural shim injected into the page.
                     let mut style_selectors: HashMap<String, Vec<String>> = HashMap::new();
+                    let mut procedural_filters: Vec<String> = Vec::new();
                     for raw in url_specific_resources.procedural_actions.iter() {
                         let Ok(filter) = serde_json::from_str::<
                             adblock::cosmetic_filter_cache::ProceduralOrActionFilter,
                         >(raw) else {
                             continue;
                         };
-                        if let Some((selector, style)) = filter.as_css() {
-                            style_selectors.entry(selector).or_default().push(style);
+                        match filter.as_css() {
+                            Some((selector, style)) => {
+                                style_selectors.entry(selector).or_default().push(style);
+                            }
+                            None => procedural_filters.push(raw.clone()),
                         }
                     }
 
@@ -189,6 +200,7 @@ impl Blocker {
                                 hidden_selectors,
                                 style_selectors,
                                 injected_script,
+                                procedural_filters,
                             }));
                 }
                 RequestKind::Url(network_url) => {

--- a/privaxy/src/server/configuration/mod.rs
+++ b/privaxy/src/server/configuration/mod.rs
@@ -34,6 +34,8 @@ pub enum ConfigurationError {
     CaError(#[from] CaError),
     #[error("an error occured while trying to deserialize configuration file")]
     DeserializeError(#[from] toml::de::Error),
+    #[error("an error occured while trying to serialize configuration")]
+    SerializeError(#[from] toml::ser::Error),
     #[error("this directory was not found")]
     DirectoryNotFound,
     #[error("file system error")]
@@ -59,6 +61,20 @@ pub struct Configuration {
     pub filters: Vec<Filter>,
     #[serde(default)]
     pub auth: Auth,
+    #[serde(default)]
+    pub debug: DebugConfig,
+}
+
+/// Opt-in diagnostics. Off by default — these add visible/observable behavior to
+/// proxied pages, so they should only be enabled while troubleshooting.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DebugConfig {
+    /// Surface errors thrown by injected uBO scriptlets to the page console
+    /// (`console.error('[privaxy scriptlet]', e)`) instead of swallowing them.
+    /// Useful for spotting a silently-failing scriptlet; noisy and reveals
+    /// Privaxy is in the path, so default off.
+    #[serde(default)]
+    pub scriptlet_console_logging: bool,
 }
 
 #[derive(Error, Debug)]
@@ -130,9 +146,26 @@ impl Configuration {
     pub async fn save(&self) -> ConfigurationResult<()> {
         let configuration_file_path = get_config_file();
 
-        let configuration_serialized = toml::to_string_pretty(&self).unwrap();
+        let configuration_serialized = toml::to_string_pretty(&self)?;
 
-        fs::write(configuration_file_path, configuration_serialized).await?;
+        // Write to a temporary file in the same directory, then atomically
+        // rename it over the target. This guarantees the live config is never
+        // observed in a half-written state: readers see either the old file or
+        // the fully-written new one, even if the process crashes mid-write.
+        let temp_file_path = get_base_directory()?.join(format!(
+            "{CONFIGURATION_FILE_NAME}.{}.tmp",
+            generate_random_hex(8)
+        ));
+
+        if let Err(err) = fs::write(&temp_file_path, configuration_serialized).await {
+            let _ = fs::remove_file(&temp_file_path).await;
+            return Err(ConfigurationError::FileSystemError(err));
+        }
+
+        if let Err(err) = fs::rename(&temp_file_path, &configuration_file_path).await {
+            let _ = fs::remove_file(&temp_file_path).await;
+            return Err(ConfigurationError::FileSystemError(err));
+        }
 
         Ok(())
     }
@@ -312,6 +345,7 @@ impl Configuration {
             ),
             custom_filters: Vec::new(),
             auth: Auth::new_initialized(),
+            debug: DebugConfig::default(),
         })
     }
 }

--- a/privaxy/src/server/lib.rs
+++ b/privaxy/src/server/lib.rs
@@ -358,6 +358,9 @@ async fn privaxy_backend(
     let config = read_configuration(&configuration_save_lock).await;
     let network_config = &config.network;
     let doh_config = network_config.doh.clone();
+    // Read once per (re)start; the backend loop re-runs this on reload, so
+    // toggling the setting in the UI takes effect after its notify_reload.
+    let scriptlet_debug_logging = config.debug.scriptlet_console_logging;
 
     // The hyper client is only used to perform upgrades. We don't need to
     // handle compression.
@@ -390,6 +393,7 @@ async fn privaxy_backend(
                     client_ip_address,
                     local_exclusion_store.clone(),
                     doh_config.clone(),
+                    scriptlet_debug_logging,
                 )
             }))
         }

--- a/privaxy/src/server/proxy/html_rewriter.rs
+++ b/privaxy/src/server/proxy/html_rewriter.rs
@@ -31,7 +31,17 @@ pub struct Rewriter {
     // reference to the globals they hook (setTimeout, eval, etc.), so this is
     // injected early into `<head>` rather than appended at end-of-body.
     injected_script: Option<String>,
+    // Procedural cosmetic filters (`:has-text`, `:upward`, `:xpath`, …) that
+    // can't be reduced to plain CSS. Each entry is one JSON-encoded
+    // `ProceduralOrActionFilter`; they're handed to the in-page shim injected
+    // into `<head>` alongside the scriptlets.
+    procedural_filters: Vec<String>,
 }
+
+/// In-page evaluator for procedural cosmetic filters. Defines the idempotent
+/// `window.__privaxyApplyProcedural(filters)` global; see the source file for
+/// the supported operators and actions.
+const PROCEDURAL_COSMETICS_SHIM: &str = include_str!("../../resources/procedural_cosmetics.js");
 
 impl Rewriter {
     pub(crate) fn new(
@@ -42,6 +52,7 @@ impl Rewriter {
         statistics: Statistics,
         csp_nonce: String,
         injected_script: Option<String>,
+        procedural_filters: Vec<String>,
     ) -> Self {
         Self {
             url,
@@ -52,7 +63,51 @@ impl Rewriter {
             internal_body_channel: mpsc::unbounded_channel(),
             csp_nonce,
             injected_script,
+            procedural_filters,
         }
+    }
+
+    /// Combine the uBO scriptlet payload and the procedural-filter shim into a
+    /// single `<head>` script body, or `None` when there's nothing to inject.
+    /// Scriptlets come first so they hook globals before page scripts run; the
+    /// procedural shim follows and sets up its own DOM observer.
+    fn build_head_script(
+        injected_script: Option<String>,
+        procedural_filters: &[String],
+    ) -> Option<String> {
+        if injected_script.is_none() && procedural_filters.is_empty() {
+            return None;
+        }
+
+        let mut payload = String::new();
+
+        if let Some(script) = injected_script {
+            // adblock-rust emits scriptlet bodies that reference an ambient
+            // `scriptletGlobals` object — uBO supplies it in its own injection
+            // wrapper, but adblock-rust leaves that to the embedder. Without it
+            // every scriptlet hits `ReferenceError: scriptletGlobals is not
+            // defined` on its first `safeSelf()`/`shouldDebug()` call, which the
+            // scriptlet's own `try { … } catch {}` swallows — so all scriptlets
+            // silently no-op. Defining it once at the top of the payload (the
+            // scriptlet bodies use dot-access, so it must be an object)
+            // so the scriptlets actually work.
+            payload.push_str("const scriptletGlobals = {};\n");
+            payload.push_str(&script);
+        }
+
+        if !procedural_filters.is_empty() {
+            if !payload.is_empty() {
+                payload.push('\n');
+            }
+            payload.push_str(PROCEDURAL_COSMETICS_SHIM);
+            // Each filter is already valid JSON, so they're spliced straight
+            // into an array literal without re-serialization.
+            payload.push_str(";window.__privaxyApplyProcedural([");
+            payload.push_str(&procedural_filters.join(","));
+            payload.push_str("]);");
+        }
+
+        Some(payload)
     }
 
     pub(crate) fn rewrite(self) {
@@ -82,7 +137,10 @@ impl Rewriter {
 
         // Mutex<Option<_>> + take() = inject at most once even if the document
         // somehow contains multiple <head> openings.
-        let pending_script = Arc::new(Mutex::new(self.injected_script));
+        let pending_script = Arc::new(Mutex::new(Self::build_head_script(
+            self.injected_script,
+            &self.procedural_filters,
+        )));
         let head_csp_nonce = csp_nonce.clone();
         let head_statistics = statistics.clone();
 
@@ -186,8 +244,6 @@ impl Rewriter {
                 break;
             }
             if let Some(adblock_properties) = adblock_properties {
-                let mut response_has_been_modified = false;
-
                 let blocker_result = adblock_requester
                     .get_cosmetic_response(
                         adblock_properties.url,
@@ -205,11 +261,15 @@ impl Rewriter {
                 let style_selectors: String = blocker_result
                     .style_selectors
                     .into_iter()
-                    .map(|(selector, content)| {
-                        response_has_been_modified = true;
-                        format!("{} {{ {} }}", selector, content.join(";"))
-                    })
+                    .map(|(selector, content)| format!("{} {{ {} }}", selector, content.join(";")))
                     .collect();
+
+                // Count the response as modified whenever we inject any cosmetic
+                // rules — hide selectors as well as style selectors. Previously
+                // only style selectors flipped this flag, so pages where we hid
+                // ad elements via `display: none` were undercounted.
+                let response_has_been_modified =
+                    !hidden_selectors.is_empty() || !style_selectors.is_empty();
 
                 // Scriptlets (`blocker_result.injected_script`) are intentionally
                 // ignored here: they're injected into <head> from the rewriter

--- a/privaxy/src/server/proxy/html_rewriter.rs
+++ b/privaxy/src/server/proxy/html_rewriter.rs
@@ -36,6 +36,10 @@ pub struct Rewriter {
     // `ProceduralOrActionFilter`; they're handed to the in-page shim injected
     // into `<head>` alongside the scriptlets.
     procedural_filters: Vec<String>,
+    // When set (config `debug.scriptlet_console_logging`), the empty
+    // per-scriptlet `catch` emitted by adblock-rust is rewritten to log the
+    // caught error to the page console instead of swallowing it.
+    scriptlet_debug_logging: bool,
 }
 
 /// In-page evaluator for procedural cosmetic filters. Defines the idempotent
@@ -53,6 +57,7 @@ impl Rewriter {
         csp_nonce: String,
         injected_script: Option<String>,
         procedural_filters: Vec<String>,
+        scriptlet_debug_logging: bool,
     ) -> Self {
         Self {
             url,
@@ -64,6 +69,7 @@ impl Rewriter {
             csp_nonce,
             injected_script,
             procedural_filters,
+            scriptlet_debug_logging,
         }
     }
 
@@ -74,6 +80,7 @@ impl Rewriter {
     fn build_head_script(
         injected_script: Option<String>,
         procedural_filters: &[String],
+        scriptlet_debug_logging: bool,
     ) -> Option<String> {
         if injected_script.is_none() && procedural_filters.is_empty() {
             return None;
@@ -81,7 +88,16 @@ impl Rewriter {
 
         let mut payload = String::new();
 
-        if let Some(script) = injected_script {
+        if let Some(mut script) = injected_script {
+            // adblock-rust isolates each scriptlet in an empty `catch ( e ) { }`.
+            // When debugging is enabled, surface what was caught rather than
+            // swallowing it (this is what hid the missing `scriptletGlobals`).
+            if scriptlet_debug_logging {
+                script = script.replace(
+                    "} catch ( e ) { }",
+                    "} catch (e) { console.error('[privaxy scriptlet]', e); }",
+                );
+            }
             // adblock-rust emits scriptlet bodies that reference an ambient
             // `scriptletGlobals` object — uBO supplies it in its own injection
             // wrapper, but adblock-rust leaves that to the embedder. Without it
@@ -140,6 +156,7 @@ impl Rewriter {
         let pending_script = Arc::new(Mutex::new(Self::build_head_script(
             self.injected_script,
             &self.procedural_filters,
+            self.scriptlet_debug_logging,
         )));
         let head_csp_nonce = csp_nonce.clone();
         let head_statistics = statistics.clone();

--- a/privaxy/src/server/proxy/mitm.rs
+++ b/privaxy/src/server/proxy/mitm.rs
@@ -25,6 +25,7 @@ pub(crate) async fn serve_mitm_session(
     client_ip_address: IpAddr,
     local_exclusion_store: LocalExclusionStore,
     doh_config: DohConfig,
+    scriptlet_debug_logging: bool,
 ) -> Result<Response<Body>, hyper::Error> {
     let authority = match req.uri().authority().cloned() {
         Some(authority) => authority,
@@ -84,6 +85,7 @@ pub(crate) async fn serve_mitm_session(
                                             statistics.clone(),
                                             client_ip_address,
                                             doh_config.clone(),
+                                            scriptlet_debug_logging,
                                         )
                                     }),
                                 )
@@ -120,6 +122,7 @@ pub(crate) async fn serve_mitm_session(
             statistics,
             client_ip_address,
             doh_config,
+            scriptlet_debug_logging,
         )
         .await
     }

--- a/privaxy/src/server/proxy/serve.rs
+++ b/privaxy/src/server/proxy/serve.rs
@@ -257,6 +257,7 @@ pub(crate) async fn serve(
     statistics: Statistics,
     client_ip_address: IpAddr,
     doh_config: DohConfig,
+    scriptlet_debug_logging: bool,
 ) -> Result<Response<Body>, hyper::Error> {
     let scheme_string = scheme.to_string();
 
@@ -469,6 +470,7 @@ pub(crate) async fn serve(
             csp_nonce.expect("csp_nonce is Some whenever is_html"),
             head_cosmetics.injected_script,
             head_cosmetics.procedural_filters,
+            scriptlet_debug_logging,
         );
 
         tokio::task::spawn_blocking(|| rewriter.rewrite());

--- a/privaxy/src/server/proxy/serve.rs
+++ b/privaxy/src/server/proxy/serve.rs
@@ -451,14 +451,14 @@ pub(crate) async fn serve(
     if is_html {
         let (sender_rewriter, receiver_rewriter) = crossbeam_channel::unbounded::<Bytes>();
 
-        // Resolve the URL-scoped scriptlet payload up-front so the rewriter can
-        // prepend it inside <head> before any page scripts execute. The
-        // end-of-body cosmetic lookup still runs for hide/style selectors,
-        // which depend on collected IDs/classes.
-        let injected_script = adblock_requester
+        // Resolve the URL-scoped payloads up-front so the rewriter can prepend
+        // them inside <head> before any page scripts execute: the uBO scriptlet
+        // and the procedural cosmetic filters (both URL-specific, not dependent
+        // on collected IDs/classes). The end-of-body cosmetic lookup still runs
+        // for hide/style selectors, which do depend on collected IDs/classes.
+        let head_cosmetics = adblock_requester
             .get_cosmetic_response(match_url.clone(), Vec::new(), Vec::new())
-            .await
-            .injected_script;
+            .await;
 
         let rewriter = Rewriter::new(
             match_url.clone(),
@@ -467,7 +467,8 @@ pub(crate) async fn serve(
             sender,
             statistics,
             csp_nonce.expect("csp_nonce is Some whenever is_html"),
-            injected_script,
+            head_cosmetics.injected_script,
+            head_cosmetics.procedural_filters,
         );
 
         tokio::task::spawn_blocking(|| rewriter.rewrite());

--- a/privaxy/src/server/web_gui/settings/debug.rs
+++ b/privaxy/src/server/web_gui/settings/debug.rs
@@ -1,0 +1,87 @@
+use super::get_error_response;
+use crate::configuration::{Configuration, DebugConfig};
+use crate::web_gui::with_configuration_save_lock;
+use crate::web_gui::with_configuration_updater_sender;
+use crate::web_gui::with_notify_reload;
+use std::convert::Infallible;
+use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::Notify;
+use warp::filters::BoxedFilter;
+use warp::http::Response;
+use warp::Filter as RouteFilter;
+
+async fn get_debug_settings() -> Result<Box<dyn warp::Reply>, Infallible> {
+    log::debug!("Getting debug settings");
+    let configuration = match Configuration::read_from_home().await {
+        Ok(configuration) => configuration,
+        Err(err) => {
+            log::error!("Failed to read debug settings: {err}");
+            return Ok(Box::new(get_error_response(err)));
+        }
+    };
+    Ok(Box::new(warp::reply::json(&configuration.debug)))
+}
+
+async fn put_debug_settings(
+    debug_settings: DebugConfig,
+    configuration_updater_sender: Sender<Configuration>,
+    configuration_save_lock: Arc<tokio::sync::Mutex<()>>,
+    notify_reload: Arc<Notify>,
+) -> Result<Box<dyn warp::Reply>, Infallible> {
+    let guard = configuration_save_lock.lock().await;
+    let mut configuration = match Configuration::read_from_home().await {
+        Ok(configuration) => configuration,
+        Err(err) => {
+            log::error!("Failed to read configuration for debug update: {err}");
+            return Ok(Box::new(get_error_response(err)));
+        }
+    };
+
+    configuration.debug = debug_settings;
+
+    if let Err(err) = configuration.save().await {
+        log::error!("Failed to save debug settings: {err}");
+        drop(guard);
+        return Ok(Box::new(get_error_response(err)));
+    }
+    configuration_updater_sender
+        .send(configuration.clone())
+        .await
+        .unwrap();
+    drop(guard);
+
+    // The proxy reads `debug.scriptlet_console_logging` when it (re)starts, so a
+    // reload is what makes the toggle take effect on newly served pages.
+    notify_reload.notify_waiters();
+
+    Ok(Box::new(
+        Response::builder()
+            .status(http::StatusCode::NO_CONTENT)
+            .body("".to_string()),
+    ))
+}
+
+pub(super) fn create_routes(
+    configuration_updater_sender: Sender<Configuration>,
+    configuration_save_lock: Arc<tokio::sync::Mutex<()>>,
+    notify_reload: Arc<Notify>,
+) -> BoxedFilter<(impl warp::Reply,)> {
+    let get_route = warp::get()
+        .and(warp::path::end())
+        .and_then(get_debug_settings);
+
+    let put_route = warp::put()
+        .and(warp::path::end())
+        .and(warp::body::json())
+        .and(with_configuration_updater_sender(
+            configuration_updater_sender.clone(),
+        ))
+        .and(with_configuration_save_lock(
+            configuration_save_lock.clone(),
+        ))
+        .and(with_notify_reload(notify_reload.clone()))
+        .and_then(put_debug_settings);
+
+    get_route.or(put_route).boxed()
+}

--- a/privaxy/src/server/web_gui/settings/mod.rs
+++ b/privaxy/src/server/web_gui/settings/mod.rs
@@ -7,6 +7,7 @@ use warp::filters::BoxedFilter;
 use warp::Filter as RouteFilter;
 
 mod ca_certificate;
+mod debug;
 mod network;
 mod pac;
 
@@ -33,8 +34,15 @@ pub(crate) fn create_routes(
         notify_reload.clone(),
     ));
 
+    let debug_settings_route = warp::path("debug").and(debug::create_routes(
+        configuration_updater_sender.clone(),
+        configuration_save_lock.clone(),
+        notify_reload.clone(),
+    ));
+
     network_settings_route
         .or(ca_cert_route)
         .or(pac_settings_route)
+        .or(debug_settings_route)
         .boxed()
 }

--- a/web_frontend/src/debug.rs
+++ b/web_frontend/src/debug.rs
@@ -1,0 +1,170 @@
+use reqwasm::http::Request;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+use yew::{html, Component, Context, Html};
+
+/// Mirrors the backend `configuration::DebugConfig`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DebugConfig {
+    #[serde(default)]
+    pub scriptlet_console_logging: bool,
+}
+
+pub enum Message {
+    Loaded(DebugConfig),
+    ToggleScriptletLogging(bool),
+    SaveSucceeded(DebugConfig),
+    SaveFailed(String),
+}
+
+pub struct DebugSettingsPage {
+    config: DebugConfig,
+    loaded: bool,
+    saving: bool,
+    saved: bool,
+    error: Option<String>,
+}
+
+impl Component for DebugSettingsPage {
+    type Message = Message;
+    type Properties = ();
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let link = ctx.link().clone();
+        spawn_local(async move {
+            match Request::get("/api/settings/debug").send().await {
+                Ok(response) if response.ok() => {
+                    if let Ok(config) = response.json::<DebugConfig>().await {
+                        link.send_message(Message::Loaded(config));
+                    }
+                }
+                _ => log::error!("Failed to load debug settings"),
+            }
+        });
+
+        Self {
+            config: DebugConfig::default(),
+            loaded: false,
+            saving: false,
+            saved: false,
+            error: None,
+        }
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Message::Loaded(config) => {
+                self.config = config;
+                self.loaded = true;
+                true
+            }
+            Message::ToggleScriptletLogging(value) => {
+                // Optimistically reflect the new value, then persist. The PUT
+                // triggers a backend reload, so it takes effect on newly served
+                // pages.
+                self.config.scriptlet_console_logging = value;
+                self.saving = true;
+                self.saved = false;
+                self.error = None;
+                let config = self.config.clone();
+                let link = ctx.link().clone();
+                spawn_local(async move {
+                    let body = serde_json::to_string(&config).unwrap();
+                    match Request::put("/api/settings/debug")
+                        .header("Content-Type", "application/json")
+                        .body(body)
+                        .send()
+                        .await
+                    {
+                        Ok(response) if response.ok() => {
+                            link.send_message(Message::SaveSucceeded(config));
+                        }
+                        Ok(response) => {
+                            link.send_message(Message::SaveFailed(format!(
+                                "Failed to save (HTTP {})",
+                                response.status()
+                            )));
+                        }
+                        Err(err) => link.send_message(Message::SaveFailed(format!("{err}"))),
+                    }
+                });
+                true
+            }
+            Message::SaveSucceeded(config) => {
+                self.config = config;
+                self.saving = false;
+                self.saved = true;
+                self.error = None;
+                true
+            }
+            Message::SaveFailed(message) => {
+                self.saving = false;
+                self.saved = false;
+                self.error = Some(message);
+                true
+            }
+        }
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        if !self.loaded {
+            return html! { <div>{"Loading..."}</div> };
+        }
+
+        let on_toggle = ctx.link().callback(|e: MouseEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            Message::ToggleScriptletLogging(input.checked())
+        });
+
+        let status = if self.saving {
+            html! { <span class="text-sm text-gray-400 ml-2">{"Saving..."}</span> }
+        } else if self.saved {
+            html! { <span class="text-sm text-green-600 ml-2">{"Saved"}</span> }
+        } else {
+            html! {}
+        };
+
+        html! {
+            <>
+                <div class="pt-1.5 mb-4">
+                    <h1 class="text-2xl font-bold text-gray-900">{ "Debug" }</h1>
+                </div>
+
+                <fieldset class="mb-8" style="width: 100%;">
+                    <legend class="text-lg font-medium text-gray-900">{ "Scriptlet diagnostics" }</legend>
+                    <div class="mt-4 border-t border-b border-gray-200 divide-y divide-gray-200">
+                        <div class="mb-4" style="display: flex; flex-direction: column; width: 100%; padding: 2px 0;">
+                            <div style="display: flex; align-items: center; width: 100%;">
+                                <div class="text-gray-500" style="width: 260px; text-align: left; padding-right: 4px;">
+                                    { "Log scriptlet errors to console" }
+                                </div>
+                                <div style="flex-grow: 1;">
+                                    <input
+                                        checked={self.config.scriptlet_console_logging}
+                                        onclick={on_toggle}
+                                        disabled={self.saving}
+                                        type="checkbox"
+                                        class="focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 rounded"
+                                    />
+                                    { status }
+                                </div>
+                            </div>
+                            <div style="margin-left: 260px;">
+                                <p class="text-gray-400 text-sm">
+                                    { "Surface errors thrown by injected uBO scriptlets in the page's developer console as " }
+                                    <span class="font-mono bg-gray-100 px-1">{ "[privaxy scriptlet]" }</span>
+                                    { " entries, instead of silently swallowing them. Noisy and reveals that Privaxy is intercepting the page \u{2014} leave off unless troubleshooting." }
+                                </p>
+                                if let Some(error) = &self.error {
+                                    <p class="text-red-500 text-xs italic">{ error.clone() }</p>
+                                }
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </>
+        }
+    }
+}

--- a/web_frontend/src/main.rs
+++ b/web_frontend/src/main.rs
@@ -10,6 +10,7 @@ mod auth;
 mod blocking_enabled;
 mod button;
 mod dashboard;
+mod debug;
 mod filterlists;
 mod filters;
 mod general;

--- a/web_frontend/src/settings.rs
+++ b/web_frontend/src/settings.rs
@@ -1,4 +1,5 @@
 use crate::account::AccountSettings;
+use crate::debug::DebugSettingsPage;
 use crate::filters::Filters;
 use crate::general::GeneralSettings;
 use crate::pac::PacSettingsPage;
@@ -22,6 +23,8 @@ pub enum SettingsRoute {
     Pac,
     #[at("/settings/account")]
     Account,
+    #[at("/settings/debug")]
+    Debug,
 }
 
 pub fn switch_settings(route: &SettingsRoute) -> Html {
@@ -111,6 +114,11 @@ pub fn switch_settings(route: &SettingsRoute) -> Html {
 
             html! { <AccountSettings /> }
         }
+        SettingsRoute::Debug => {
+            set_title("Settings - Debug");
+
+            html! { <DebugSettingsPage /> }
+        }
     };
 
     html! {<div class="md:grid md:grid-cols-8">
@@ -121,6 +129,7 @@ pub fn switch_settings(route: &SettingsRoute) -> Html {
         <Link<SettingsRoute> classes={get_classes(*route, SettingsRoute::CustomFilters)} to={SettingsRoute::CustomFilters}> <span class="truncate">{ "Custom filters" }</span></Link<SettingsRoute>>
         <Link<SettingsRoute> classes={get_classes(*route, SettingsRoute::Pac)} to={SettingsRoute::Pac}> <span class="truncate">{ "PAC" }</span></Link<SettingsRoute>>
         <Link<SettingsRoute> classes={get_classes(*route, SettingsRoute::Account)} to={SettingsRoute::Account}> <span class="truncate">{ "Account" }</span></Link<SettingsRoute>>
+        <Link<SettingsRoute> classes={get_classes(*route, SettingsRoute::Debug)} to={SettingsRoute::Debug}> <span class="truncate">{ "Debug" }</span></Link<SettingsRoute>>
     </nav>
         <div class="container mx-auto px-4 sm:px-6 lg:px-8 mt-4 sm:col-span-6">{ content }</div>
     </div>


### PR DESCRIPTION
- Injected uBlock scriptlets now actually run
  - Even after the 0.7.0 scriptlet repair, every injected `##+js(...)` scriptlet was a silent no-op. adblock-rust emits scriptlet bodies that reference an ambient `scriptletGlobals` object (uBlock Origin supplies it in its own injector; adblock-rust leaves it to the embedder), so the first internal call threw `ReferenceError: scriptletGlobals is not defined`, which each scriptlet's own `try/catch` swallowed. Privaxy now defines `scriptletGlobals` at the top of the injected payload, so `abort-current-script`, `prevent-addEventListener`, `abort-on-property-read`, `set-cookie`, etc. take effect.
- Procedural cosmetic filtering
  - Non-CSS procedural filters are no longer dropped (previously only filters reducible to plain CSS were applied). `:has-text`, `:matches-css`/`-before`/`-after`, `:matches-attr`, `:matches-path`, `:min-text-length`, `:upward`, `:xpath`, and the `:remove()`/`:style()`/`remove-attr`/`remove-class` actions are now evaluated in-page by an injected shim.